### PR TITLE
check out temp branch for linting job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install ruff pre-commit
+      - name: Switch to a temporary branch
+        run: |
+          git checkout -b _ci_branch_
       - name: Run pre-commit on all files
         env:
           RUFF_OUTPUT_FORMAT: github


### PR DESCRIPTION
This should fix the failure we get when merging into main, see [pre-commit no-commit-to-branch docs](https://github.com/pre-commit/pre-commit-hooks). This hook is meant to prevent commit and pushing to main/master from a local workspace (not CI).