### PR TITLE
run tests before pypi deployment

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -5,7 +5,52 @@ on:
     types: [published]
 
 jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      max-parallel: 1
+      matrix:
+        os: [ ubuntu-latest ] # TODO: add windows and macos to matrix
+        python-version: [ "3.10", "3.11", "3.12" ]
+    env:
+      DISPLAY: ':99.0'
+      QT_MAC_WANTS_LAYER: 1  # PyQT gui tests involving qtbot interaction on macOS will fail without this
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Miniforge
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: latest
+          activate-environment: badger-dev
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install libs for testing a pyqt app on linux
+        shell: bash -el {0}
+        run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            sudo apt install xvfb herbstluftwm libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils
+            sudo /sbin/start-stop-daemon --start --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1024x768x24 -ac +extension GLX +render -noreset
+            sleep 3
+            sudo /sbin/start-stop-daemon --start --pidfile /tmp/custom_herbstluftwm_99.pid --make-pidfile --background --exec /usr/bin/herbstluftwm
+            sleep 1
+          fi
+
+      - name: Install Badger
+        shell: bash -l {0}
+        run: |
+          pip install ".[dev]"
+
+      - name: Run Tests
+        shell: bash -l {0}
+        run: |
+          python scripts/run_tests.py
+
   publish-pypi:
+    needs: test
     runs-on: ubuntu-latest
     environment: deployment
     permissions:


### PR DESCRIPTION
Adds another run of tests within the pypi deployment workflow file to ensure no tests are failing in between merging and manually creating a release (eg from upstream changes, as happened this week).