### PR TITLE
UX patch

### DIFF
--- a/src/badger/gui/acr/components/history_navigator.py
+++ b/src/badger/gui/acr/components/history_navigator.py
@@ -1,4 +1,5 @@
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QTreeWidget, QTreeWidgetItem
+from PyQt5.QtGui import QFont
 from PyQt5.QtCore import Qt
 from badger.archive import get_base_run_filename
 from badger.utils import run_names_to_dict
@@ -12,14 +13,21 @@ class HistoryNavigator(QWidget):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         self.tree_widget = QTreeWidget()
-        self.tree_widget.setHeaderHidden(True)
+
+        self.tree_widget.setHeaderLabels(["History Navigator"])
+        header = self.tree_widget.header()
+        # Set the font of the header to bold
+        bold_font = QFont()
+        bold_font.setBold(True)
+        header.setFont(bold_font)
+
         self.tree_widget.setMinimumHeight(256)
         layout.addWidget(self.tree_widget)
 
         self.runs = None  # all runs to be shown in the tree widget
         self.setStyleSheet("""
             QTreeWidget {
-                background-color: #455364;
+                background-color: #37414F;
             }
         """)
 

--- a/src/badger/gui/acr/pages/home_page.py
+++ b/src/badger/gui/acr/pages/home_page.py
@@ -11,6 +11,7 @@ from PyQt5.QtWidgets import (
     QSplitter,
     QVBoxLayout,
     QWidget,
+    QLabel,
 )
 
 from badger.archive import (
@@ -92,7 +93,7 @@ class BadgerHomePage(QWidget):
 
         # History run browser
         self.history_browser = history_browser = HistoryNavigator()
-        history_browser.setMinimumWidth(360)
+        history_browser.setFixedWidth(360)
 
         # Splitter
         splitter = QSplitter(Qt.Horizontal)
@@ -115,8 +116,21 @@ class BadgerHomePage(QWidget):
         vbox_run_view.addWidget(run_monitor)
 
         # Data table
+        panel_table = QWidget()
+        panel_table.setMinimumHeight(180)
+        vbox_table = QVBoxLayout(panel_table)
+        vbox_table.setContentsMargins(0, 0, 0, 0)
+        title_label = QLabel("Run Data")
+        title_label.setStyleSheet("""
+            background-color: #455364;
+            font-weight: bold;
+            padding: 4px;
+        """)
+        title_label.setAlignment(Qt.AlignCenter)  # Center-align the title
+        vbox_table.addWidget(title_label, 0)
         self.run_table = run_table = data_table()
         run_table.set_uneditable()  # should not be editable
+        vbox_table.addWidget(run_table, 1)
 
         # Routine view
         self.routine_view = routine_view = QWidget()  # for consistent bg
@@ -138,12 +152,16 @@ class BadgerHomePage(QWidget):
         splitter_run = QSplitter(Qt.Horizontal)
         splitter_run.setStretchFactor(0, 1)
         splitter_run.setStretchFactor(1, 1)
-        splitter_run.setStretchFactor(2, 0)
         vbox_run.addWidget(splitter_run, 1)
 
+        splitter_data = QSplitter(Qt.Vertical)
+        splitter_data.setStretchFactor(0, 1)
+        splitter_data.setStretchFactor(1, 0)
+        splitter_data.addWidget(panel_monitor)
+        splitter_data.addWidget(panel_table)
+
         splitter_run.addWidget(routine_view)
-        splitter_run.addWidget(panel_monitor)
-        splitter_run.addWidget(run_table)
+        splitter_run.addWidget(splitter_data)
 
         vbox_run.addWidget(run_action_bar, 0)
 
@@ -152,12 +170,9 @@ class BadgerHomePage(QWidget):
         splitter.addWidget(panel_run)
 
         # Set initial sizes (left fixed, middle and right equal)
-        total_width = 1640  # Total width of the splitter
-        fixed_width = 360  # Fixed width for the left panel
-        remaining_width = total_width - fixed_width
-        equal_width = remaining_width // 2
-        splitter.setSizes([fixed_width, remaining_width])
-        splitter_run.setSizes([equal_width, equal_width, 0])
+        splitter.setSizes([1, 1])
+        splitter_run.setSizes([1, 1])
+        splitter_data.setSizes([800, 180])
 
         self.status_bar = status_bar = BadgerStatusBar()
         status_bar.set_summary("Badger is ready!")
@@ -298,6 +313,9 @@ class BadgerHomePage(QWidget):
                 row = _row
                 continue
 
+            return
+
+        if row == -1:
             return
 
         self.run_monitor.jump_to_solution(row)

--- a/src/badger/gui/acr/windows/main_window.py
+++ b/src/badger/gui/acr/windows/main_window.py
@@ -66,7 +66,7 @@ class BadgerMainWindow(QMainWindow):
         if os.getenv("DEMO"):
             self.resize(1280, 720)
         else:
-            self.resize(1640, 800)
+            self.resize(1720, 960)
         self.center()
 
         # Add menu bar

--- a/src/badger/gui/default/components/data_table.py
+++ b/src/badger/gui/default/components/data_table.py
@@ -15,6 +15,19 @@ stylesheet = """
     }
 """
 
+stylesheet_data = """
+    QTableWidget
+    {
+        margin: 0px 8px 8px 8px;
+        alternate-background-color: #262E38;
+    }
+    QTableWidget::item::selected
+    {
+        background-color: #B3E5FC;
+        color: #000000;
+    }
+"""
+
 
 # https://stackoverflow.com/questions/60715462/how-to-copy-and-paste-multiple-cells-in-qtablewidget-in-pyqt5
 class TableWithCopy(QTableWidget):
@@ -103,7 +116,7 @@ def add_row(table, row):
 def data_table(data=None):
     table = TableWithCopy()
     table.setAlternatingRowColors(True)
-    table.setStyleSheet(stylesheet)
+    table.setStyleSheet(stylesheet_data)
     # table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
     return update_table(table, data)
 

--- a/src/badger/gui/default/components/run_monitor.py
+++ b/src/badger/gui/default/components/run_monitor.py
@@ -720,7 +720,7 @@ class BadgerOptMonitor(QWidget):
             self.inspector_state.setValue(value)
         self.inspector_variable.setValue(value)
 
-        self.sig_inspect.emit(idx)
+        self.sig_inspect.emit(int(idx))
 
     def closest_ts(self, t):
         # Get the closest timestamp in data regarding t


### PR DESCRIPTION
- Add section header in the run history browser
- Fix an issue preventing the sync between the data inspector and the data table
- Move the data table to under the monitor again, add a header, and open it up in minimal height by default