### PR TITLE
Patch for Xopt 2.5.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,7 @@ dependencies = [
     "qdarkstyle>=3.0",
     "pillow",
     "requests",
-    "xopt>=2.2.2",
-    "botorch==0.12.0"
+    "xopt>=2.5.4",
 ]
 dynamic = ["version"]
 [tool.setuptools_scm]

--- a/src/badger/core_subprocess.py
+++ b/src/badger/core_subprocess.py
@@ -91,11 +91,6 @@ def run_routine_subprocess(
     # set required arguments
     try:
         routine = load_run(args["routine_filename"])
-        # Call the reset generator API before starting the optimization
-        try:
-            routine.generator.turbo_controller.reset()
-        except AttributeError:  # if not BO generators
-            pass
         # TODO: might need to consider the case where routine.data is None?
         if routine.data is not None:
             routine.data = routine.data.iloc[0:0]  # reset the data

--- a/src/badger/core_subprocess.py
+++ b/src/badger/core_subprocess.py
@@ -91,6 +91,11 @@ def run_routine_subprocess(
     # set required arguments
     try:
         routine = load_run(args["routine_filename"])
+        # Call the reset generator API before starting the optimization
+        try:
+            routine.generator.turbo_controller.reset()
+        except AttributeError:  # if not BO generators
+            pass
         # TODO: might need to consider the case where routine.data is None?
         if routine.data is not None:
             routine.data = routine.data.iloc[0:0]  # reset the data

--- a/src/badger/environment.py
+++ b/src/badger/environment.py
@@ -186,8 +186,7 @@ class Environment(BaseModel, ABC):
             variable_names = self.variable_names
 
         variable_names_new = [
-            name for name in variable_names
-            if not len(self.variables.get(name, []))
+            name for name in variable_names if not len(self.variables.get(name, []))
         ]
 
         # Get bound one by one due to potential failure

--- a/src/badger/environment.py
+++ b/src/badger/environment.py
@@ -186,15 +186,23 @@ class Environment(BaseModel, ABC):
             variable_names = self.variable_names
 
         variable_names_new = [
-            name for name in variable_names if not len(self.variables.get(name, []))
+            name for name in variable_names
+            if not len(self.variables.get(name, []))
         ]
-        if len(variable_names_new):
-            self.variables.update(self.get_bounds(variable_names_new))
 
-        # Set a default value for the bounds if not defined
-        default_value = [-1, 1]
+        # Get bound one by one due to potential failure
+        for name in variable_names_new:
+            try:
+                bound = self.get_bound(name)
+            except Exception:
+                raise BadgerEnvVarError(f"Failed to get bound for {name}")
 
-        return {k: self.variables.get(k, default_value) for k in variable_names}
+            if bound[1] <= bound[0]:
+                raise BadgerEnvVarError(f"Invalid bound for {name}: {bound}")
+
+            self.variables.update({name: bound})
+
+        return {k: self.variables[k] for k in variable_names}
 
 
 def instantiate_env(env_class, configs, manager=None):

--- a/src/badger/gui/acr/components/routine_page.py
+++ b/src/badger/gui/acr/components/routine_page.py
@@ -4,7 +4,6 @@ import copy
 from functools import partial
 import os
 import yaml
-from packaging.version import parse
 
 import numpy as np
 import pandas as pd
@@ -934,8 +933,6 @@ class BadgerRoutinePage(QWidget):
 
     def _compose_routine(self) -> Routine:
         # Compose the routine
-        xopt_version = get_xopt_version()
-
         # Metadata
         name = self.edit_save.text() or self.edit_save.placeholderText()
         description = self.edit_descr.toPlainText()

--- a/src/badger/gui/default/components/var_table.py
+++ b/src/badger/gui/default/components/var_table.py
@@ -311,11 +311,6 @@ class VariableTable(QTableWidget):
                 # TODO: handle this case? Right now I don't think it should happen
                 raise "Environment cannot be found for new variable bounds!"
 
-            # Sanitize vrange
-            # TODO: raise a heads-up regarding the invalid bounds
-            if vrange[1] <= vrange[0]:
-                vrange = [-1000, 1000]  # fallback to some default values
-
             # Add checkbox only when a PV is entered
             self.setCellWidget(idx, 0, QCheckBox())
 
@@ -350,8 +345,8 @@ class VariableTable(QTableWidget):
         self.env = instantiate_env(self.env_class, self.configs)
 
         value = self.env.get_variable(name)
-        bounds = self.env.get_bound(name)
-        return value, bounds
+        bound = self.env._get_bounds([name])[name]
+        return value, bound
 
     def add_variable(self, name, lb, ub):
         var = {name: [lb, ub]}


### PR DESCRIPTION
- Use Xopt's default sanity check when compose routine
- Attempt to use TuRBO's reset method to clean up fields before starting a new run
- Move variable bound check into base env class, raise error if check fails to pass