### PR TITLE
Fix issue with tensors when using the MOBO generator 

### DIFF
--- a/src/badger/core_subprocess.py
+++ b/src/badger/core_subprocess.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import logging
 import time
 import traceback
@@ -200,10 +201,10 @@ def run_routine_subprocess(
             solution = convert_to_solution(result, routine)
             opt_logger.update(Events.OPTIMIZATION_STEP, solution)
 
-            # TODO if paused tell user it is paused
+            generator_copy = deepcopy(routine.generator)
 
             if evaluate:
-                evaluate_queue[0].send((routine.data, routine.generator))
+                evaluate_queue[0].send((routine.data, generator_copy))
 
             # archive Xopt state after each step
             if archive:


### PR DESCRIPTION
Issue: When using the MOBO generator the optimization will fail after running through initial points due to an unknown tensor that is not available except at runtime being having the property `require_grad` property being set to `True`.

Solution: Although not entirely clear, if you create a `deepcopy` of the generator before it is sent across threads the unknown tensor becomes serializable and does not have the aforementioned error.