### PR TITLE
feat: allow optionally using pyside6 instead of pyqt5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks.git
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: no-commit-to-branch
       - id: trailing-whitespace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 requires-python = ">=3.10, <3.13"
 dependencies = [
     "coolname",
+    "qtpy",
     "pyqt5",
     "pyqtgraph",
     "qdarkstyle>=3.0",
@@ -38,6 +39,7 @@ version_file = "src/badger/_version.py"
 
 [project.optional-dependencies]
 dev = [
+    "pyside6",
     "pytest",
     "pytest-cov",
     "pytest-qt",

--- a/src/badger/errors.py
+++ b/src/badger/errors.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QMessageBox
+from qtpy.QtWidgets import QMessageBox
 import traceback
 import sys
 

--- a/src/badger/gui/acr/__init__.py
+++ b/src/badger/gui/acr/__init__.py
@@ -2,9 +2,9 @@ from importlib import resources
 import signal
 import sys
 import time
-from PyQt5.QtWidgets import QApplication
-from PyQt5.QtGui import QFont, QIcon
-from PyQt5 import QtCore
+from qtpy.QtWidgets import QApplication
+from qtpy.QtGui import QFont, QIcon
+from qtpy import QtCore
 from qdarkstyle import load_stylesheet, LightPalette, DarkPalette
 
 from badger.settings import init_settings

--- a/src/badger/gui/acr/components/action_bar.py
+++ b/src/badger/gui/acr/components/action_bar.py
@@ -1,7 +1,7 @@
-from PyQt5.QtWidgets import QWidget, QHBoxLayout
-from PyQt5.QtWidgets import QToolButton, QMenu, QAction
-from PyQt5.QtGui import QIcon, QFont
-from PyQt5.QtCore import pyqtSignal
+from qtpy.QtWidgets import QWidget, QHBoxLayout
+from qtpy.QtWidgets import QToolButton, QMenu
+from qtpy.QtGui import QAction, QFont, QIcon
+from qtpy.QtCore import Signal
 from importlib import resources
 from badger.gui.default.utils import create_button
 
@@ -84,17 +84,17 @@ QToolButton
 
 
 class BadgerActionBar(QWidget):
-    sig_start = pyqtSignal()
-    sig_start_until = pyqtSignal()
-    sig_stop = pyqtSignal()
+    sig_start = Signal()
+    sig_start_until = Signal()
+    sig_stop = Signal()
 
-    sig_delete_run = pyqtSignal()
-    sig_logbook = pyqtSignal()
-    sig_reset_env = pyqtSignal()
-    sig_jump_to_optimal = pyqtSignal()
-    sig_dial_in = pyqtSignal()
-    sig_ctrl = pyqtSignal(bool)
-    sig_open_extensions_palette = pyqtSignal()
+    sig_delete_run = Signal()
+    sig_logbook = Signal()
+    sig_reset_env = Signal()
+    sig_jump_to_optimal = Signal()
+    sig_dial_in = Signal()
+    sig_ctrl = Signal(bool)
+    sig_open_extensions_palette = Signal()
 
     def __init__(self, parent=None):
         super().__init__(parent)

--- a/src/badger/gui/acr/components/archive_search.py
+++ b/src/badger/gui/acr/components/archive_search.py
@@ -1,16 +1,15 @@
 import logging
-from typing import List
-from PyQt5.QtGui import QDrag, QKeyEvent
-from PyQt5.QtCore import (
+from typing import Any, List
+from qtpy.QtGui import QDrag, QKeyEvent
+from qtpy.QtCore import (
     QAbstractTableModel,
     QMimeData,
     QModelIndex,
     QObject,
     Qt,
-    QVariant,
-    pyqtSignal,
+    Signal,
 )
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QAbstractItemView,
     QHBoxLayout,
     QHeaderView,
@@ -54,17 +53,17 @@ class ArchiveResultsTableModel(QAbstractTableModel):
             return 0
         return len(self.column_names)
 
-    def data(self, index: QModelIndex, role: int) -> QVariant:
+    def data(self, index: QModelIndex, role: int) -> str | None:
         """Return the data for the associated role. Currently only supporting DisplayRole."""
         if not index.isValid():
-            return QVariant()
+            return None
 
         if role != Qt.DisplayRole:
-            return QVariant()
+            return None
 
         return self.results_list[index.row()]
 
-    def headerData(self, section, orientation, role=Qt.DisplayRole) -> QVariant:
+    def headerData(self, section, orientation, role=Qt.DisplayRole) -> Any:
         """Return data associated with the header"""
         if role != Qt.DisplayRole:
             return super().headerData(section, orientation, role)
@@ -117,7 +116,7 @@ class ArchiveSearchWidget(QWidget):
         The parent item of this widget
     """
 
-    append_variables_requested = pyqtSignal(str)
+    append_variables_requested = Signal(str)
 
     def __init__(self, environment, parent: QObject = None) -> None:
         super().__init__(parent=parent)

--- a/src/badger/gui/acr/components/env_cbox.py
+++ b/src/badger/gui/acr/components/env_cbox.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QVBoxLayout,
     QHBoxLayout,
     QPushButton,
@@ -6,13 +6,13 @@ from PyQt5.QtWidgets import (
     QPlainTextEdit,
     QLineEdit,
 )
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QCheckBox,
     QStyledItemDelegate,
     QLabel,
     QListWidget,
 )
-from PyQt5.QtCore import QRegExp, QPropertyAnimation
+from qtpy.QtCore import QRegularExpression, QPropertyAnimation
 
 from badger.gui.acr.components.archive_search import ArchiveSearchWidget
 from badger.gui.default.components.collapsible_box import CollapsibleBox
@@ -463,12 +463,12 @@ class BadgerEnvBox(QWidget):
 
     def filter_var(self):
         keyword = self.edit_var.text()
-        rx = QRegExp(keyword)
+        rx = QRegularExpression(keyword)
 
         _variables = []
         for var in self.var_table.all_variables:
             vname = next(iter(var))
-            if rx.indexIn(vname, 0) != -1:
+            if rx.match(vname).hasMatch():
                 _variables.append(var)
 
         self.var_table.update_variables(_variables, 1)
@@ -478,12 +478,12 @@ class BadgerEnvBox(QWidget):
 
     def filter_obj(self):
         keyword = self.edit_obj.text()
-        rx = QRegExp(keyword)
+        rx = QRegularExpression(keyword)
 
         _objectives = []
         for obj in self.obj_table.all_objectives:
             oname = next(iter(obj))
-            if rx.indexIn(oname, 0) != -1:
+            if rx.match(oname).hasMatch():
                 _objectives.append(obj)
 
         self.obj_table.update_objectives(_objectives, 1)

--- a/src/badger/gui/acr/components/generator_cbox.py
+++ b/src/badger/gui/acr/components/generator_cbox.py
@@ -1,11 +1,11 @@
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QVBoxLayout,
     QHBoxLayout,
     QPushButton,
     QWidget,
     QPlainTextEdit,
 )
-from PyQt5.QtWidgets import QComboBox, QCheckBox, QStyledItemDelegate, QLabel
+from qtpy.QtWidgets import QComboBox, QCheckBox, QStyledItemDelegate, QLabel
 from badger.gui.default.components.collapsible_box import CollapsibleBox
 from badger.settings import init_settings
 from badger.gui.default.utils import (

--- a/src/badger/gui/acr/components/history_navigator.py
+++ b/src/badger/gui/acr/components/history_navigator.py
@@ -1,6 +1,6 @@
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QTreeWidget, QTreeWidgetItem
-from PyQt5.QtGui import QFont
-from PyQt5.QtCore import Qt
+from qtpy.QtWidgets import QWidget, QVBoxLayout, QTreeWidget, QTreeWidgetItem
+from qtpy.QtGui import QFont
+from qtpy.QtCore import Qt
 from badger.archive import get_base_run_filename
 from badger.utils import run_names_to_dict
 

--- a/src/badger/gui/acr/components/routine_editor.py
+++ b/src/badger/gui/acr/components/routine_editor.py
@@ -1,18 +1,18 @@
-from PyQt5.QtWidgets import QVBoxLayout, QHBoxLayout, QWidget, QPushButton
-from PyQt5.QtWidgets import QTextEdit, QStackedWidget
-from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtGui import QFont
+from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QWidget, QPushButton
+from qtpy.QtWidgets import QTextEdit, QStackedWidget
+from qtpy.QtCore import Signal
+from qtpy.QtGui import QFont
 from badger.gui.acr.components.routine_page import BadgerRoutinePage
 
 from badger.routine import Routine
 
 
 class BadgerRoutineEditor(QWidget):
-    sig_saved = pyqtSignal()
-    sig_canceled = pyqtSignal()
-    sig_deleted = pyqtSignal()
-    sig_load_template = pyqtSignal(str)
-    sig_save_template = pyqtSignal(str)
+    sig_saved = Signal()
+    sig_canceled = Signal()
+    sig_deleted = Signal()
+    sig_load_template = Signal(str)
+    sig_save_template = Signal(str)
 
     def __init__(self):
         super().__init__()

--- a/src/badger/gui/acr/components/routine_page.py
+++ b/src/badger/gui/acr/components/routine_page.py
@@ -7,11 +7,11 @@ import yaml
 
 import numpy as np
 import pandas as pd
-from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtWidgets import QLineEdit, QLabel, QPushButton, QFileDialog
-from PyQt5.QtWidgets import QListWidgetItem, QMessageBox, QWidget, QTabWidget
-from PyQt5.QtWidgets import QVBoxLayout, QHBoxLayout, QScrollArea
-from PyQt5.QtWidgets import QTableWidgetItem, QPlainTextEdit
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtWidgets import QLineEdit, QLabel, QPushButton, QFileDialog
+from qtpy.QtWidgets import QListWidgetItem, QMessageBox, QWidget, QTabWidget
+from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QScrollArea
+from qtpy.QtWidgets import QTableWidgetItem, QPlainTextEdit
 from coolname import generate_slug
 from xopt import VOCS
 from xopt.generators import get_generator_defaults, all_generator_names
@@ -59,9 +59,9 @@ LABEL_WIDTH = 96
 
 
 class BadgerRoutinePage(QWidget):
-    sig_updated = pyqtSignal(str, str)  # routine name, routine description
-    sig_load_template = pyqtSignal(str)  # template path
-    sig_save_template = pyqtSignal(str)  # template path
+    sig_updated = Signal(str, str)  # routine name, routine description
+    sig_load_template = Signal(str)  # template path
+    sig_save_template = Signal(str)  # template path
 
     def __init__(self):
         super().__init__()

--- a/src/badger/gui/acr/components/status_bar.py
+++ b/src/badger/gui/acr/components/status_bar.py
@@ -1,7 +1,7 @@
 from importlib import resources
-from PyQt5.QtWidgets import QHBoxLayout, QWidget, QPushButton
-from PyQt5.QtGui import QIcon
-from PyQt5.QtCore import Qt, QSize
+from qtpy.QtWidgets import QHBoxLayout, QWidget, QPushButton
+from qtpy.QtGui import QIcon
+from qtpy.QtCore import Qt, QSize
 from badger.gui.acr.windows.settings_dialog import BadgerSettingsDialog
 from badger.gui.default.components.eliding_label import SimpleElidedLabel
 

--- a/src/badger/gui/acr/pages/home_page.py
+++ b/src/badger/gui/acr/pages/home_page.py
@@ -3,11 +3,10 @@ import traceback
 from importlib import resources
 
 from pandas import DataFrame
-from PyQt5.QtCore import pyqtSignal, Qt
-from PyQt5.QtGui import QIcon, QKeySequence
-from PyQt5.QtWidgets import (
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtGui import QIcon, QKeySequence, QShortcut
+from qtpy.QtWidgets import (
     QMessageBox,
-    QShortcut,
     QSplitter,
     QVBoxLayout,
     QWidget,
@@ -35,7 +34,7 @@ from badger.gui.acr.components.action_bar import BadgerActionBar
 from badger.utils import get_header
 from badger.settings import init_settings
 
-# from PyQt5.QtGui import QBrush, QColor
+# from qtpy.QtGui import QBrush, QColor
 from badger.gui.default.windows.message_dialog import BadgerScrollableMessageBox
 from badger.gui.default.utils import ModalOverlay
 
@@ -60,8 +59,8 @@ QPushButton
 
 
 class BadgerHomePage(QWidget):
-    sig_routine_activated = pyqtSignal(bool)
-    sig_routine_invalid = pyqtSignal()
+    sig_routine_activated = Signal(bool)
+    sig_routine_invalid = Signal()
 
     def __init__(self, process_manager=None):
         super().__init__()

--- a/src/badger/gui/acr/windows/main_window.py
+++ b/src/badger/gui/acr/windows/main_window.py
@@ -2,8 +2,9 @@ import os
 from importlib import metadata
 from typing import Dict
 
-from PyQt5.QtCore import QThread
-from PyQt5.QtWidgets import QDesktopWidget, QMainWindow, QMessageBox, QStackedWidget
+from qtpy.QtCore import QThread
+from qtpy.QtGui import QGuiApplication
+from qtpy.QtWidgets import QMainWindow, QMessageBox, QStackedWidget
 
 from badger.gui.default.components.create_process import CreateProcess
 from badger.gui.default.components.process_manager import ProcessManager
@@ -86,7 +87,7 @@ class BadgerMainWindow(QMainWindow):
 
     def center(self) -> None:
         qr = self.frameGeometry()
-        cp = QDesktopWidget().availableGeometry().center()
+        cp = QGuiApplication.primaryScreen().availableGeometry().center()
 
         qr.moveCenter(cp)
         self.move(qr.topLeft())

--- a/src/badger/gui/acr/windows/settings_dialog.py
+++ b/src/badger/gui/acr/windows/settings_dialog.py
@@ -1,6 +1,5 @@
-# from PyQt5.QtCore import QRegExp
-# from PyQt5.QtGui import QRegExpValidator
-from PyQt5.QtWidgets import (
+# from qtpy.QtGui import QRegularExpressionValidator
+from qtpy.QtWidgets import (
     # QComboBox,
     QGridLayout,
     QVBoxLayout,
@@ -8,7 +7,7 @@ from PyQt5.QtWidgets import (
     QLabel,
     QLineEdit,
 )
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QDialog,
     QDialogButtonBox,
     QApplication,
@@ -42,7 +41,7 @@ class BadgerSettingsDialog(QDialog):
 
         vbox = QVBoxLayout(self)
 
-        # validator = QRegExpValidator(QRegExp(r"^[0-9]\d*(\.\d+)?$"))
+        # validator = QRegularExpressionValidator(r"^[0-9]\d*(\.\d+)?$")
 
         widget_settings = QWidget(self)
         grid = QGridLayout(widget_settings)

--- a/src/badger/gui/default/__init__.py
+++ b/src/badger/gui/default/__init__.py
@@ -2,9 +2,9 @@ from importlib import resources
 import signal
 import sys
 import time
-from PyQt5.QtWidgets import QApplication
-from PyQt5.QtGui import QFont, QIcon
-from PyQt5 import QtCore
+from qtpy.QtWidgets import QApplication
+from qtpy.QtGui import QFont, QIcon
+from qtpy import QtCore
 from qdarkstyle import load_stylesheet, LightPalette, DarkPalette
 
 from badger.settings import init_settings

--- a/src/badger/gui/default/components/analysis_extensions.py
+++ b/src/badger/gui/default/components/analysis_extensions.py
@@ -2,9 +2,9 @@ from abc import abstractmethod
 from typing import Optional, cast
 
 import pyqtgraph as pg
-from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtWidgets import QDialog, QVBoxLayout, QMessageBox
-from PyQt5.QtGui import QCloseEvent
+from qtpy.QtCore import Signal
+from qtpy.QtWidgets import QDialog, QVBoxLayout, QMessageBox
+from qtpy.QtGui import QCloseEvent
 from badger.gui.default.components.bo_visualizer.bo_plotter import BOPlotWidget
 from badger.routine import Routine
 
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 class AnalysisExtension(QDialog):
-    window_closed = pyqtSignal(object)
+    window_closed = Signal(object)
 
     def __init__(self, parent: Optional[QDialog] = None):
         super().__init__(parent=parent)

--- a/src/badger/gui/default/components/bo_visualizer/bo_plotter.py
+++ b/src/badger/gui/default/components/bo_visualizer/bo_plotter.py
@@ -1,14 +1,14 @@
 from functools import wraps
 from typing import Callable, Optional, ParamSpec, cast
-from PyQt5.QtWidgets import QHBoxLayout, QWidget, QVBoxLayout
-from PyQt5.QtWidgets import QSizePolicy
+from qtpy.QtWidgets import QHBoxLayout, QWidget, QVBoxLayout
+from qtpy.QtWidgets import QSizePolicy
 
 from badger.gui.default.components.bo_visualizer.types import ConfigurableOptions
 from badger.routine import Routine
 from .ui_components import UIComponents
 from .plotting_area import PlottingArea
 from .model_logic import ModelLogic
-from PyQt5.QtCore import Qt
+from qtpy.QtCore import Qt
 from xopt.generators.bayesian.bayesian_generator import BayesianGenerator
 
 import logging

--- a/src/badger/gui/default/components/bo_visualizer/model_logic.py
+++ b/src/badger/gui/default/components/bo_visualizer/model_logic.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from xopt import VOCS
 
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QTableWidgetItem,
 )
 

--- a/src/badger/gui/default/components/bo_visualizer/plotting_area.py
+++ b/src/badger/gui/default/components/bo_visualizer/plotting_area.py
@@ -3,7 +3,7 @@ from matplotlib import pyplot as plt
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 from matplotlib.axes import Axes
-from PyQt5.QtWidgets import QVBoxLayout, QWidget, QLayout
+from qtpy.QtWidgets import QVBoxLayout, QWidget, QLayout
 from xopt.generators.bayesian.visualize import (
     visualize_generator_model,
 )

--- a/src/badger/gui/default/components/bo_visualizer/ui_components.py
+++ b/src/badger/gui/default/components/bo_visualizer/ui_components.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QVBoxLayout,
     QHBoxLayout,
     QComboBox,
@@ -11,7 +11,7 @@ from PyQt5.QtWidgets import (
     QCheckBox,
     QHeaderView,
 )
-from PyQt5.QtCore import Qt
+from qtpy.QtCore import Qt
 from typing import Optional, cast
 
 from badger.gui.default.components.bo_visualizer.types import ConfigurableOptions

--- a/src/badger/gui/default/components/collapsible_box.py
+++ b/src/badger/gui/default/components/collapsible_box.py
@@ -1,4 +1,4 @@
-from PyQt5 import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 
 stylesheet_toolbutton = """
@@ -11,7 +11,7 @@ QToolButton
 
 # https://stackoverflow.com/a/56293688
 class ScrollArea(QtWidgets.QScrollArea):
-    resized = QtCore.pyqtSignal()
+    resized = QtCore.Signal()
 
     def resizeEvent(self, e):
         self.resized.emit()
@@ -71,7 +71,7 @@ class CollapsibleBox(QtWidgets.QWidget):
             QtCore.QPropertyAnimation(self.content_area, b"maximumHeight")
         )
 
-    @QtCore.pyqtSlot()
+    @QtCore.Slot()
     def start_animation(self):
         checked = self.toggle_button.isChecked()
         arrow_type = QtCore.Qt.DownArrow if checked else QtCore.Qt.RightArrow
@@ -92,7 +92,7 @@ class CollapsibleBox(QtWidgets.QWidget):
     def updateContentLayout(self):
         if (
             self.toggle_button.isChecked()
-            and self.toggle_animation.state() != self.toggle_animation.Running
+            and self.toggle_animation.state() != QtCore.QAbstractAnimation.Running
         ):
             content_height = self.content_area.layout().sizeHint().height()
             self.setMinimumHeight(self.collapsed_height + content_height)

--- a/src/badger/gui/default/components/constraint_item.py
+++ b/src/badger/gui/default/components/constraint_item.py
@@ -1,12 +1,12 @@
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QHBoxLayout,
     QPushButton,
     QWidget,
     QDoubleSpinBox,
     QAbstractSpinBox,
 )
-from PyQt5.QtWidgets import QComboBox, QCheckBox, QStyledItemDelegate
-from PyQt5.QtCore import Qt
+from qtpy.QtWidgets import QComboBox, QCheckBox, QStyledItemDelegate
+from qtpy.QtCore import Qt
 from badger.gui.default.utils import (
     MouseWheelWidgetAdjustmentGuard,
     NoHoverFocusComboBox,

--- a/src/badger/gui/default/components/create_process.py
+++ b/src/badger/gui/default/components/create_process.py
@@ -1,6 +1,6 @@
 from multiprocessing import Event, Pipe, Process, Queue
 
-from PyQt5.QtCore import pyqtSignal, QObject
+from qtpy.QtCore import Signal, QObject
 
 from badger.core_subprocess import run_routine_subprocess
 
@@ -13,8 +13,8 @@ class CreateProcess(QObject):
         The new process will be started, but will be holding until the wait_event is set.
     """
 
-    finished = pyqtSignal()
-    subprocess_prepared = pyqtSignal(object)
+    finished = Signal()
+    subprocess_prepared = Signal(object)
 
     def create_subprocess(self) -> None:
         """

--- a/src/badger/gui/default/components/data_table.py
+++ b/src/badger/gui/default/components/data_table.py
@@ -1,6 +1,6 @@
 from pandas import DataFrame
-from PyQt5.QtWidgets import QApplication, QTableWidget, QTableWidgetItem
-from PyQt5.QtCore import Qt
+from qtpy.QtWidgets import QApplication, QTableWidget, QTableWidgetItem
+from qtpy.QtCore import Qt
 
 
 stylesheet = """

--- a/src/badger/gui/default/components/eliding_label.py
+++ b/src/badger/gui/default/components/eliding_label.py
@@ -1,5 +1,5 @@
 # https://stackoverflow.com/a/67628976/4263605
-from PyQt5 import QtCore, QtWidgets, QtGui
+from qtpy import QtCore, QtWidgets, QtGui
 
 
 class ElidingLabel(QtWidgets.QLabel):
@@ -36,7 +36,7 @@ class ElidingLabel(QtWidgets.QLabel):
 
     """
 
-    elision_changed = QtCore.pyqtSignal(bool)
+    elision_changed = QtCore.Signal(bool)
 
     def __init__(self, text="", mode=QtCore.Qt.ElideMiddle, **kwargs):
         super().__init__(**kwargs)

--- a/src/badger/gui/default/components/env_cbox.py
+++ b/src/badger/gui/default/components/env_cbox.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QVBoxLayout,
     QHBoxLayout,
     QPushButton,
@@ -6,14 +6,14 @@ from PyQt5.QtWidgets import (
     QPlainTextEdit,
     QLineEdit,
 )
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QCheckBox,
     QStyledItemDelegate,
     QLabel,
     QListWidget,
     QFrame,
 )
-from PyQt5.QtCore import QRegExp
+from qtpy.QtCore import QRegularExpression
 
 from badger.gui.default.components.collapsible_box import CollapsibleBox
 from badger.gui.default.components.var_table import VariableTable
@@ -364,12 +364,12 @@ class BadgerEnvBox(CollapsibleBox):
 
     def filter_var(self):
         keyword = self.edit_var.text()
-        rx = QRegExp(keyword)
+        rx = QRegularExpression(keyword)
 
         _variables = []
         for var in self.var_table.all_variables:
             vname = next(iter(var))
-            if rx.indexIn(vname, 0) != -1:
+            if rx.match(vname).hasMatch():
                 _variables.append(var)
 
         self.var_table.update_variables(_variables, 1)
@@ -379,12 +379,12 @@ class BadgerEnvBox(CollapsibleBox):
 
     def filter_obj(self):
         keyword = self.edit_obj.text()
-        rx = QRegExp(keyword)
+        rx = QRegularExpression(keyword)
 
         _objectives = []
         for obj in self.obj_table.all_objectives:
             oname = next(iter(obj))
-            if rx.indexIn(oname, 0) != -1:
+            if rx.match(oname).hasMatch():
                 _objectives.append(obj)
 
         self.obj_table.update_objectives(_objectives, 1)

--- a/src/badger/gui/default/components/extensions_palette.py
+++ b/src/badger/gui/default/components/extensions_palette.py
@@ -1,6 +1,6 @@
 import traceback
 
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QMainWindow,
     QPushButton,
     QVBoxLayout,
@@ -9,7 +9,7 @@ from PyQt5.QtWidgets import (
     QMessageBox,
     QSizePolicy,
 )
-from PyQt5.QtCore import Qt
+from qtpy.QtCore import Qt
 from badger.gui.default.components.analysis_extensions import (
     AnalysisExtension,
     ParetoFrontViewer,

--- a/src/badger/gui/default/components/filter_cbox.py
+++ b/src/badger/gui/default/components/filter_cbox.py
@@ -1,5 +1,5 @@
-from PyQt5.QtWidgets import QVBoxLayout, QHBoxLayout, QWidget
-from PyQt5.QtWidgets import QComboBox, QStyledItemDelegate, QLabel
+from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QWidget
+from qtpy.QtWidgets import QComboBox, QStyledItemDelegate, QLabel
 from badger.gui.default.components.collapsible_box import CollapsibleBox
 
 

--- a/src/badger/gui/default/components/generator_cbox.py
+++ b/src/badger/gui/default/components/generator_cbox.py
@@ -1,11 +1,11 @@
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QVBoxLayout,
     QHBoxLayout,
     QPushButton,
     QWidget,
     QPlainTextEdit,
 )
-from PyQt5.QtWidgets import QComboBox, QCheckBox, QStyledItemDelegate, QLabel
+from qtpy.QtWidgets import QComboBox, QCheckBox, QStyledItemDelegate, QLabel
 from badger.gui.default.components.collapsible_box import CollapsibleBox
 from badger.settings import init_settings
 from badger.gui.default.utils import (

--- a/src/badger/gui/default/components/history_navigator.py
+++ b/src/badger/gui/default/components/history_navigator.py
@@ -1,5 +1,5 @@
-from PyQt5.QtWidgets import QComboBox, QTreeWidget, QTreeWidgetItem
-from PyQt5.QtCore import QModelIndex, Qt
+from qtpy.QtWidgets import QComboBox, QTreeWidget, QTreeWidgetItem
+from qtpy.QtCore import QModelIndex, Qt
 from badger.archive import get_base_run_filename
 from badger.utils import run_names_to_dict
 

--- a/src/badger/gui/default/components/labeled_lineedit.py
+++ b/src/badger/gui/default/components/labeled_lineedit.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QHBoxLayout, QLabel, QLineEdit, QWidget
+from qtpy.QtWidgets import QHBoxLayout, QLabel, QLineEdit, QWidget
 
 
 def labeled_lineedit(name, text, width_name=64, placeholder=None, readonly=True):

--- a/src/badger/gui/default/components/obj_table.py
+++ b/src/badger/gui/default/components/obj_table.py
@@ -1,5 +1,5 @@
 from typing import Any, List, Dict, Optional
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QTableWidget,
     QTableWidgetItem,
     QHeaderView,
@@ -8,7 +8,7 @@ from PyQt5.QtWidgets import (
     QComboBox,
     QStyledItemDelegate,
 )
-from PyQt5.QtGui import QDropEvent, QDragEnterEvent, QDragMoveEvent
+from qtpy.QtGui import QDropEvent, QDragEnterEvent, QDragMoveEvent
 
 
 class ObjectiveTable(QTableWidget):

--- a/src/badger/gui/default/components/process_manager.py
+++ b/src/badger/gui/default/components/process_manager.py
@@ -1,6 +1,6 @@
 from typing import Dict, Optional
 
-from PyQt5.QtCore import pyqtSignal, QObject
+from qtpy.QtCore import Signal, QObject
 
 
 class ProcessManager(QObject):
@@ -9,7 +9,7 @@ class ProcessManager(QObject):
     which can be used by Badger to run optimizations.
     """
 
-    processQueueUpdated = pyqtSignal(object)
+    processQueueUpdated = Signal(object)
 
     def __init__(self) -> None:
         super().__init__()

--- a/src/badger/gui/default/components/reorderable_table.py
+++ b/src/badger/gui/default/components/reorderable_table.py
@@ -5,7 +5,7 @@
 # https://creativecommons.org/publicdomain/zero/1.0/
 # https://creativecommons.org/publicdomain/zero/1.0/legalcode
 
-from PyQt5 import QtWidgets, QtGui
+from qtpy import QtWidgets, QtGui
 
 
 class MyModel(QtGui.QStandardItemModel):

--- a/src/badger/gui/default/components/robust_spinbox.py
+++ b/src/badger/gui/default/components/robust_spinbox.py
@@ -1,5 +1,5 @@
-from PyQt5.QtWidgets import QDoubleSpinBox, QAbstractSpinBox
-from PyQt5.QtCore import Qt
+from qtpy.QtWidgets import QDoubleSpinBox, QAbstractSpinBox
+from qtpy.QtCore import Qt
 from badger.gui.default.utils import MouseWheelWidgetAdjustmentGuard
 
 

--- a/src/badger/gui/default/components/routine_editor.py
+++ b/src/badger/gui/default/components/routine_editor.py
@@ -1,16 +1,16 @@
-from PyQt5.QtWidgets import QVBoxLayout, QHBoxLayout, QWidget, QPushButton
-from PyQt5.QtWidgets import QTextEdit, QStackedWidget, QScrollArea
-from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtGui import QFont
+from qtpy.QtCore import Signal
+from qtpy.QtGui import QFont
+from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QWidget, QPushButton
+from qtpy.QtWidgets import QTextEdit, QStackedWidget, QScrollArea
 from badger.gui.default.components.routine_page import BadgerRoutinePage
 
 from badger.routine import Routine
 
 
 class BadgerRoutineEditor(QWidget):
-    sig_saved = pyqtSignal()
-    sig_canceled = pyqtSignal()
-    sig_deleted = pyqtSignal()
+    sig_saved = Signal()
+    sig_canceled = Signal()
+    sig_deleted = Signal()
 
     def __init__(self):
         super().__init__()

--- a/src/badger/gui/default/components/routine_item.py
+++ b/src/badger/gui/default/components/routine_item.py
@@ -1,8 +1,8 @@
 from datetime import datetime
-from PyQt5.QtWidgets import QWidget, QHBoxLayout, QVBoxLayout, QLabel
-from PyQt5.QtWidgets import QSizePolicy, QMessageBox
-from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtGui import QFont
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtGui import QFont
+from qtpy.QtWidgets import QWidget, QHBoxLayout, QVBoxLayout, QLabel
+from qtpy.QtWidgets import QSizePolicy, QMessageBox
 from badger.gui.default.components.eliding_label import ElidingLabel
 from badger.gui.default.utils import create_button
 
@@ -62,7 +62,7 @@ QPushButton
 
 class BadgerRoutineItem(QWidget):
     # sig_del carries an id
-    sig_del = pyqtSignal(str)
+    sig_del = Signal(str)
 
     def __init__(
         self, id, name, timestamp, environment, env_dict, description="", parent=None

--- a/src/badger/gui/default/components/routine_page.py
+++ b/src/badger/gui/default/components/routine_page.py
@@ -9,11 +9,11 @@ import yaml
 
 import numpy as np
 import pandas as pd
-from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtWidgets import QGroupBox, QLineEdit, QLabel, QPushButton
-from PyQt5.QtWidgets import QListWidgetItem, QMessageBox, QWidget
-from PyQt5.QtWidgets import QVBoxLayout, QHBoxLayout
-from PyQt5.QtWidgets import QTableWidgetItem, QPlainTextEdit, QSizePolicy
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtWidgets import QGroupBox, QLineEdit, QLabel, QPushButton
+from qtpy.QtWidgets import QListWidgetItem, QMessageBox, QWidget
+from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout
+from qtpy.QtWidgets import QTableWidgetItem, QPlainTextEdit, QSizePolicy
 from coolname import generate_slug
 from pydantic import ValidationError
 from xopt import VOCS
@@ -61,7 +61,7 @@ CONS_RELATION_DICT = {
 
 
 class BadgerRoutinePage(QWidget):
-    sig_updated = pyqtSignal(str, str)  # routine name, routine description
+    sig_updated = Signal(str, str)  # routine name, routine description
 
     def __init__(self):
         super().__init__()

--- a/src/badger/gui/default/components/routine_runner.py
+++ b/src/badger/gui/default/components/routine_runner.py
@@ -4,7 +4,7 @@ import traceback
 
 import pandas as pd
 import torch  # noqa: F401. For converting dtype str to torch object.
-from PyQt5.QtCore import pyqtSignal, QObject, QTimer
+from qtpy.QtCore import Signal, QObject, QTimer
 
 from badger.errors import BadgerRunTerminated
 from badger.tests.utils import get_current_vars
@@ -18,12 +18,12 @@ logger = logging.getLogger(__name__)
 
 
 class BadgerRoutineSignals(QObject):
-    env_ready = pyqtSignal(list)
-    finished = pyqtSignal()
-    progress = pyqtSignal(object)
-    error = pyqtSignal(Exception)
-    info = pyqtSignal(str)
-    states = pyqtSignal(str)
+    env_ready = Signal(list)
+    finished = Signal()
+    progress = Signal(object)
+    error = Signal(Exception)
+    info = Signal(str)
+    states = Signal(str)
 
 
 class BadgerRoutineSubprocess:

--- a/src/badger/gui/default/components/run_monitor.py
+++ b/src/badger/gui/default/components/run_monitor.py
@@ -6,9 +6,9 @@ from typing import List
 import numpy as np
 import pandas as pd
 import pyqtgraph as pg
-from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import (
+from qtpy.QtCore import Signal
+from qtpy.QtGui import QIcon
+from qtpy.QtWidgets import (
     QCheckBox,
     QComboBox,
     QHBoxLayout,
@@ -43,23 +43,23 @@ pd.options.mode.chained_assignment = None  # default='warn'
 
 
 class BadgerOptMonitor(QWidget):
-    sig_pause = pyqtSignal(bool)  # True: pause, False: resume
-    sig_stop = pyqtSignal()
-    sig_lock = pyqtSignal(bool)  # True: lock GUI, False: unlock GUI
-    sig_new_run = pyqtSignal()  # start the new run
-    sig_run_started = pyqtSignal()  # run started
-    sig_stop_run = pyqtSignal()  # stop the run
-    sig_run_name = pyqtSignal(str)  # filename of the new run
-    sig_status = pyqtSignal(str)  # status information
-    sig_inspect = pyqtSignal(int)  # index of the inspector
-    sig_progress = pyqtSignal(pd.DataFrame)  # new evaluated solution
-    sig_del = pyqtSignal()
-    sig_routine_finished = pyqtSignal()
-    sig_lock_action = pyqtSignal()
-    sig_toggle_reset = pyqtSignal(bool)
-    sig_toggle_run = pyqtSignal(bool)
-    sig_toggle_other = pyqtSignal(bool)
-    sig_env_ready = pyqtSignal()
+    sig_pause = Signal(bool)  # True: pause, False: resume
+    sig_stop = Signal()
+    sig_lock = Signal(bool)  # True: lock GUI, False: unlock GUI
+    sig_new_run = Signal()  # start the new run
+    sig_run_started = Signal()  # run started
+    sig_stop_run = Signal()  # stop the run
+    sig_run_name = Signal(str)  # filename of the new run
+    sig_status = Signal(str)  # status information
+    sig_inspect = Signal(int)  # index of the inspector
+    sig_progress = Signal(pd.DataFrame)  # new evaluated solution
+    sig_del = Signal()
+    sig_routine_finished = Signal()
+    sig_lock_action = Signal()
+    sig_toggle_reset = Signal(bool)
+    sig_toggle_run = Signal(bool)
+    sig_toggle_other = Signal(bool)
+    sig_env_ready = Signal()
 
     def __init__(self, process_manager=None):
         super().__init__()

--- a/src/badger/gui/default/components/search_bar.py
+++ b/src/badger/gui/default/components/search_bar.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QLineEdit
+from qtpy.QtWidgets import QLineEdit
 
 
 def search_bar():

--- a/src/badger/gui/default/components/state_item.py
+++ b/src/badger/gui/default/components/state_item.py
@@ -1,5 +1,5 @@
-from PyQt5.QtWidgets import QHBoxLayout, QPushButton, QWidget
-from PyQt5.QtWidgets import QStyledItemDelegate
+from qtpy.QtWidgets import QHBoxLayout, QPushButton, QWidget
+from qtpy.QtWidgets import QStyledItemDelegate
 from badger.gui.default.utils import NoHoverFocusComboBox
 
 

--- a/src/badger/gui/default/components/status_bar.py
+++ b/src/badger/gui/default/components/status_bar.py
@@ -1,7 +1,7 @@
 from importlib import resources
-from PyQt5.QtWidgets import QHBoxLayout, QWidget, QPushButton
-from PyQt5.QtGui import QIcon
-from PyQt5.QtCore import Qt, QSize
+from qtpy.QtWidgets import QHBoxLayout, QWidget, QPushButton
+from qtpy.QtGui import QIcon
+from qtpy.QtCore import Qt, QSize
 from badger.gui.default.windows.settings_dialog import BadgerSettingsDialog
 from badger.gui.default.components.eliding_label import SimpleElidedLabel
 

--- a/src/badger/gui/default/components/var_table.py
+++ b/src/badger/gui/default/components/var_table.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QTableWidget,
     QTableWidgetItem,
     QHeaderView,
@@ -6,8 +6,8 @@ from PyQt5.QtWidgets import (
     QMessageBox,
     QAbstractItemView,
 )
-from PyQt5.QtCore import pyqtSignal, Qt
-from PyQt5.QtGui import QColor
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtGui import QColor
 from badger.gui.default.components.robust_spinbox import RobustSpinBox
 
 from badger.environment import instantiate_env
@@ -15,8 +15,8 @@ from badger.errors import BadgerInterfaceChannelError
 
 
 class VariableTable(QTableWidget):
-    sig_sel_changed = pyqtSignal()
-    sig_pv_added = pyqtSignal()
+    sig_sel_changed = Signal()
+    sig_pv_added = Signal()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/badger/gui/default/pages/home_page.py
+++ b/src/badger/gui/default/pages/home_page.py
@@ -6,9 +6,9 @@ from importlib import resources
 from typing import List
 
 from pandas import DataFrame
-from PyQt5.QtCore import pyqtSignal, Qt
-from PyQt5.QtGui import QIcon, QKeySequence
-from PyQt5.QtWidgets import (
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtGui import QIcon, QKeySequence, QShortcut
+from qtpy.QtWidgets import (
     QFileDialog,
     QHBoxLayout,
     QLabel,
@@ -16,7 +16,6 @@ from PyQt5.QtWidgets import (
     QListWidgetItem,
     QMessageBox,
     QPushButton,
-    QShortcut,
     QSplitter,
     QTabWidget,
     QVBoxLayout,
@@ -50,7 +49,7 @@ from badger.gui.default.utils import create_button
 from badger.utils import get_header, strtobool
 from badger.settings import init_settings
 
-# from PyQt5.QtGui import QBrush, QColor
+# from qtpy.QtGui import QBrush, QColor
 from badger.gui.default.windows.message_dialog import BadgerScrollableMessageBox
 from badger.gui.default.utils import ModalOverlay
 
@@ -71,7 +70,7 @@ QPushButton
 
 
 class BadgerHomePage(QWidget):
-    sig_routine_activated = pyqtSignal(bool)
+    sig_routine_activated = Signal(bool)
 
     def __init__(self, process_manager=None):
         super().__init__()

--- a/src/badger/gui/default/utils.py
+++ b/src/badger/gui/default/utils.py
@@ -1,8 +1,8 @@
 from importlib import resources
-from PyQt5.QtWidgets import QWidget, QAbstractSpinBox, QPushButton, QComboBox
-from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel
-from PyQt5.QtCore import Qt, QObject, QEvent, QSize
-from PyQt5.QtGui import QIcon
+from qtpy.QtWidgets import QWidget, QAbstractSpinBox, QPushButton, QComboBox
+from qtpy.QtWidgets import QDialog, QVBoxLayout, QLabel
+from qtpy.QtCore import Qt, QObject, QEvent, QSize
+from qtpy.QtGui import QIcon
 import copy
 
 

--- a/src/badger/gui/default/windows/add_random_dialog.py
+++ b/src/badger/gui/default/windows/add_random_dialog.py
@@ -1,6 +1,6 @@
-from PyQt5.QtWidgets import QDialog, QWidget, QHBoxLayout, QStackedWidget
-from PyQt5.QtWidgets import QVBoxLayout, QSpinBox, QPushButton
-from PyQt5.QtWidgets import QGroupBox, QLabel, QComboBox, QStyledItemDelegate
+from qtpy.QtWidgets import QDialog, QWidget, QHBoxLayout, QStackedWidget
+from qtpy.QtWidgets import QVBoxLayout, QSpinBox, QPushButton
+from qtpy.QtWidgets import QGroupBox, QLabel, QComboBox, QStyledItemDelegate
 from badger.gui.default.components.robust_spinbox import RobustSpinBox
 
 

--- a/src/badger/gui/default/windows/docs_window.py
+++ b/src/badger/gui/default/windows/docs_window.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QTextEdit,
     QHBoxLayout,
     QVBoxLayout,

--- a/src/badger/gui/default/windows/edit_script_dialog.py
+++ b/src/badger/gui/default/windows/edit_script_dialog.py
@@ -1,6 +1,6 @@
-from PyQt5.QtWidgets import QDialog, QPlainTextEdit, QVBoxLayout, QWidget
-from PyQt5.QtWidgets import QHBoxLayout, QPushButton
-from PyQt5.QtGui import QFont
+from qtpy.QtWidgets import QDialog, QPlainTextEdit, QVBoxLayout, QWidget
+from qtpy.QtWidgets import QHBoxLayout, QPushButton
+from qtpy.QtGui import QFont
 from badger.gui.default.components.syntax import PythonHighlighter
 
 

--- a/src/badger/gui/default/windows/env_docs_window.py
+++ b/src/badger/gui/default/windows/env_docs_window.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QTextEdit,
     QHBoxLayout,
     QVBoxLayout,

--- a/src/badger/gui/default/windows/expandable_message_box.py
+++ b/src/badger/gui/default/windows/expandable_message_box.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QDialog,
     QMessageBox,
     QVBoxLayout,
@@ -7,7 +7,7 @@ from PyQt5.QtWidgets import (
     QPushButton,
     QTextEdit,
 )
-from PyQt5.QtGui import QTextOption, QFont, QFontDatabase
+from qtpy.QtGui import QTextOption, QFont, QFontDatabase
 
 
 class ExpandableMessageBox(QDialog):

--- a/src/badger/gui/default/windows/lim_vrange_dialog.py
+++ b/src/badger/gui/default/windows/lim_vrange_dialog.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QDialog,
     QWidget,
     QHBoxLayout,
@@ -6,14 +6,14 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QDoubleSpinBox,
 )
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QGroupBox,
     QLabel,
     QComboBox,
     QStyledItemDelegate,
     QStackedWidget,
 )
-from PyQt5.QtCore import Qt
+from qtpy.QtCore import Qt
 
 
 class BadgerLimitVariableRangeDialog(QDialog):

--- a/src/badger/gui/default/windows/main_window.py
+++ b/src/badger/gui/default/windows/main_window.py
@@ -2,8 +2,9 @@ import os
 from importlib import metadata
 from typing import Dict
 
-from PyQt5.QtCore import QThread
-from PyQt5.QtWidgets import QDesktopWidget, QMainWindow, QMessageBox, QStackedWidget
+from qtpy.QtCore import QThread
+from qtpy.QtGui import QGuiApplication
+from qtpy.QtWidgets import QMainWindow, QMessageBox, QStackedWidget
 
 from badger.gui.default.components.create_process import CreateProcess
 from badger.gui.default.components.process_manager import ProcessManager
@@ -86,7 +87,7 @@ class BadgerMainWindow(QMainWindow):
 
     def center(self) -> None:
         qr = self.frameGeometry()
-        cp = QDesktopWidget().availableGeometry().center()
+        cp = QGuiApplication.primaryScreen().availableGeometry().center()
 
         qr.moveCenter(cp)
         self.move(qr.topLeft())

--- a/src/badger/gui/default/windows/message_dialog.py
+++ b/src/badger/gui/default/windows/message_dialog.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QDialog,
     QMessageBox,
     QVBoxLayout,
@@ -8,7 +8,7 @@ from PyQt5.QtWidgets import (
     QScrollArea,
     QTextEdit,
 )
-from PyQt5.QtGui import QTextOption, QFont, QFontDatabase
+from qtpy.QtGui import QTextOption, QFont, QFontDatabase
 # from ..components.eliding_label import ElidingLabel
 
 

--- a/src/badger/gui/default/windows/review_dialog.py
+++ b/src/badger/gui/default/windows/review_dialog.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QDialog, QDialogButtonBox, QTextBrowser, QVBoxLayout
+from qtpy.QtWidgets import QDialog, QDialogButtonBox, QTextBrowser, QVBoxLayout
 
 from badger.routine import Routine
 from badger.utils import get_yaml_string

--- a/src/badger/gui/default/windows/settings_dialog.py
+++ b/src/badger/gui/default/windows/settings_dialog.py
@@ -1,6 +1,5 @@
-from PyQt5.QtCore import QRegExp
-from PyQt5.QtGui import QRegExpValidator
-from PyQt5.QtWidgets import (
+from qtpy.QtGui import QRegularExpressionValidator
+from qtpy.QtWidgets import (
     QComboBox,
     QGridLayout,
     QVBoxLayout,
@@ -8,7 +7,7 @@ from PyQt5.QtWidgets import (
     QLabel,
     QLineEdit,
 )
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QDialog,
     QDialogButtonBox,
     QApplication,
@@ -45,7 +44,7 @@ class BadgerSettingsDialog(QDialog):
 
         vbox = QVBoxLayout(self)
 
-        validator = QRegExpValidator(QRegExp(r"^[0-9]\d*(\.\d+)?$"))
+        validator = QRegularExpressionValidator(r"^[0-9]\d*(\.\d+)?$")
 
         widget_settings = QWidget(self)
         grid = QGridLayout(widget_settings)

--- a/src/badger/gui/default/windows/terminition_condition_dialog.py
+++ b/src/badger/gui/default/windows/terminition_condition_dialog.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QDialog,
     QWidget,
     QHBoxLayout,
@@ -7,7 +7,7 @@ from PyQt5.QtWidgets import (
     QSpinBox,
     QDoubleSpinBox,
 )
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QGroupBox,
     QLabel,
     QComboBox,

--- a/src/badger/gui/default/windows/var_dialog.py
+++ b/src/badger/gui/default/windows/var_dialog.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QDialog,
     QWidget,
     QHBoxLayout,
@@ -6,7 +6,7 @@ from PyQt5.QtWidgets import (
     QPushButton,
     QVBoxLayout,
 )
-from PyQt5.QtWidgets import QGroupBox, QMessageBox
+from qtpy.QtWidgets import QGroupBox, QMessageBox
 from badger.gui.default.components.labeled_lineedit import labeled_lineedit
 from badger.environment import instantiate_env
 

--- a/src/badger/tests/test_create_process.py
+++ b/src/badger/tests/test_create_process.py
@@ -3,7 +3,7 @@ import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
-from PyQt5.QtWidgets import QApplication
+from qtpy.QtWidgets import QApplication
 
 app = QApplication(sys.argv)
 

--- a/src/badger/tests/test_gui_basic.py
+++ b/src/badger/tests/test_gui_basic.py
@@ -3,7 +3,7 @@ import time
 from unittest.mock import patch
 
 import pytest
-from PyQt5.QtCore import QEventLoop, Qt, QTimer
+from qtpy.QtCore import QEventLoop, Qt, QTimer
 
 
 @pytest.fixture(scope="session")

--- a/src/badger/tests/test_home_page.py
+++ b/src/badger/tests/test_home_page.py
@@ -1,7 +1,7 @@
 import multiprocessing
 
 import pytest
-from PyQt5.QtCore import QEventLoop, QTimer
+from qtpy.QtCore import QEventLoop, QTimer
 
 
 @pytest.fixture(scope="session")

--- a/src/badger/tests/test_routine_page.py
+++ b/src/badger/tests/test_routine_page.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
-from PyQt5.QtCore import Qt, QTimer
-from PyQt5.QtWidgets import QApplication
+from qtpy.QtCore import Qt, QTimer
+from qtpy.QtWidgets import QApplication
 
 
 def test_routine_page_init(qtbot):

--- a/src/badger/tests/test_routine_runner.py
+++ b/src/badger/tests/test_routine_runner.py
@@ -1,9 +1,9 @@
 import multiprocessing
 
 import pytest
-from PyQt5.QtCore import QEventLoop, Qt, QTimer
-from PyQt5.QtTest import QSignalSpy
-from PyQt5.QtWidgets import QApplication
+from qtpy.QtCore import QEventLoop, Qt, QTimer
+from qtpy.QtTest import QSignalSpy
+from qtpy.QtWidgets import QApplication
 from unittest.mock import Mock
 
 

--- a/src/badger/tests/test_run_monitor.py
+++ b/src/badger/tests/test_run_monitor.py
@@ -4,10 +4,10 @@ from unittest.mock import patch
 
 import numpy as np
 import pytest
-from PyQt5.QtCore import QEventLoop, QPointF, Qt, QTimer
-from PyQt5.QtGui import QMouseEvent
-from PyQt5.QtTest import QSignalSpy
-from PyQt5.QtWidgets import QApplication, QMessageBox
+from qtpy.QtCore import QEventLoop, QPointF, Qt, QTimer
+from qtpy.QtGui import QMouseEvent
+from qtpy.QtTest import QSignalSpy
+from qtpy.QtWidgets import QApplication, QMessageBox
 
 
 class TestRunMonitor:
@@ -357,10 +357,8 @@ class TestRunMonitor:
 
         monitor.inspector_objective.setValue(9)
 
-        with patch(
-            "PyQt5.QtWidgets.QMessageBox.question", return_value=QMessageBox.Yes
-        ):
-            # with patch("PyQt5.QtWidgets.QMessageBox.information") as mock_info:
+        with patch("qtpy.QtWidgets.QMessageBox.question", return_value=QMessageBox.Yes):
+            # with patch("qtpy.QtWidgets.QMessageBox.information") as mock_info:
             qtbot.mouseClick(action_bar.btn_set, Qt.MouseButton.LeftButton)
             # mock_info.assert_called_once()
 
@@ -373,10 +371,8 @@ class TestRunMonitor:
         # Reset env and confirm
         spy = QSignalSpy(action_bar.btn_reset.clicked)
 
-        with patch(
-            "PyQt5.QtWidgets.QMessageBox.question", return_value=QMessageBox.Yes
-        ):
-            # with patch("PyQt5.QtWidgets.QMessageBox.information") as mock_info:
+        with patch("qtpy.QtWidgets.QMessageBox.question", return_value=QMessageBox.Yes):
+            # with patch("qtpy.QtWidgets.QMessageBox.information") as mock_info:
             qtbot.mouseClick(action_bar.btn_reset, Qt.MouseButton.LeftButton)
             # mock_info.assert_called_once()
 
@@ -406,9 +402,7 @@ class TestRunMonitor:
         monitor.inspector_objective.setValue(2)
 
         spy = QSignalSpy(action_bar.btn_set.clicked)
-        with patch(
-            "PyQt5.QtWidgets.QMessageBox.question", return_value=QMessageBox.Yes
-        ):
+        with patch("qtpy.QtWidgets.QMessageBox.question", return_value=QMessageBox.Yes):
             qtbot.mouseClick(action_bar.btn_set, Qt.MouseButton.LeftButton)
         assert len(spy) == 1
 
@@ -423,7 +417,7 @@ class TestRunMonitor:
 
         # monitor.plot_x_axis = False
 
-        # with patch("PyQt5.QtWidgets.QMessageBox.question", return_value=QMessageBox.Yes):
+        # with patch("qtpy.QtWidgets.QMessageBox.question", return_value=QMessageBox.Yes):
         #     qtbot.mouseClick(monitor.btn_set, Qt.MouseButton.LeftButton)
 
         # not_time_x_view_range = monitor.plot_var.getViewBox().viewRange()[0]
@@ -512,7 +506,7 @@ class TestRunMonitor:
         action_bar.run_until_action.trigger()
 
         # Check if critical violation alert being triggered
-        with patch("PyQt5.QtWidgets.QMessageBox.warning", return_value=QMessageBox.Yes):
+        with patch("qtpy.QtWidgets.QMessageBox.warning", return_value=QMessageBox.Yes):
             while monitor.running:
                 qtbot.wait(100)
 


### PR DESCRIPTION
Closes #63

To run on PySide6, install the `pyside6` package and run with `QT_API=pyside6 badger -g` (or uninstall the `pyqt5` package, since it will autoselect the nearest available package).