### PR TITLE
Slight modification to loading templates and message for dialing in solution

### DIFF
--- a/src/badger/gui/acr/components/routine_page.py
+++ b/src/badger/gui/acr/components/routine_page.py
@@ -371,8 +371,9 @@ class BadgerRoutinePage(QWidget):
             additional_variables = template_dict["additional_variables"]
         except KeyError:
             additional_variables = {}
-        for i in self.vars_env:
-            all_variables.update(i)
+        if self.vars_env:
+            for i in self.vars_env:
+                all_variables.update(i)
         if additional_variables:  # there are additional variables
             env = self.create_env()
             for vname in additional_variables:
@@ -399,11 +400,15 @@ class BadgerRoutinePage(QWidget):
         self.env_box.relative_to_curr.blockSignals(False)
         self.toggle_relative_to_curr(flag_relative, refresh=False)
 
-        # Always use ranges stored in template
-        self.env_box.var_table.set_bounds(vocs.variables, signal=False)
-        # Populate the initial table anyways, auto mode or not
-        self.clear_init_table(reset_actions=False)
-        self.update_init_table()
+        if env_name:
+            if flag_relative:
+                bounds = self.calc_auto_bounds()
+                self.env_box.var_table.set_bounds(bounds, signal=False)
+            else:
+                self.env_box.var_table.set_bounds(vocs.variables, signal=False)
+            # Populate the initial table anyways, auto mode or not
+            self.clear_init_table(reset_actions=False)
+            self.update_init_table(force=True)
 
         # set objectives
         self.env_box.obj_table.set_selected(vocs.objectives)

--- a/src/badger/gui/default/components/run_monitor.py
+++ b/src/badger/gui/default/components/run_monitor.py
@@ -809,18 +809,20 @@ class BadgerOptMonitor(QWidget):
             pos = idx = int(self.inspector_objective.value())
         variable_names = self.vocs.variable_names
         solution = df[variable_names].to_numpy()[idx]
+        curr_vars = get_current_vars(self.routine)
 
         reply = QMessageBox.question(
             self,
             "Apply Solution",
-            f"Are you sure you want to apply the selected solution at {solution} to env?",
+            f"Are you sure you want to apply the selected solution:\n"
+            + "\n".join(f"{variable_names[i]}: {round(curr_vars[i],3)} -> {solution[i]}," for i in range(len(variable_names)))
+            + "\nto " + f"{self.routine.environment.name}?",
             QMessageBox.Yes | QMessageBox.No,
             QMessageBox.No,
         )
         if reply != QMessageBox.Yes:
             return
 
-        curr_vars = get_current_vars(self.routine)
         self.routine.environment._set_variables(dict(zip(variable_names, solution)))
         # center around the inspector
         x_range = self.plot_var.getViewBox().viewRange()[0]

--- a/src/badger/gui/default/components/run_monitor.py
+++ b/src/badger/gui/default/components/run_monitor.py
@@ -815,7 +815,7 @@ class BadgerOptMonitor(QWidget):
             self,
             "Apply Solution",
             f"Are you sure you want to apply the selected solution:\n"
-            + "\n".join(f"{variable_names[i]}: {round(curr_vars[i],3)} -> {solution[i]}," for i in range(len(variable_names)))
+            + "\n".join(f"{variable_names[i]}: {round(curr_vars[i],3)} -> {round(solution[i],3)}," for i in range(len(variable_names)))
             + "\nto " + f"{self.routine.environment.name}?",
             QMessageBox.Yes | QMessageBox.No,
             QMessageBox.No,
@@ -831,7 +831,7 @@ class BadgerOptMonitor(QWidget):
 
         updated_vars = get_current_vars(self.routine)
         self.sig_status.emit(
-            f"Dial in solution: Env vars {curr_vars} -> {updated_vars}"
+            f"Dial in solution: {[f'{variable_names[i]}: {round(curr_vars[i],4)} -> {round(updated_vars[i],4)}' for i in range(len(variable_names))]}"
         )
         # QMessageBox.information(
         #     self, 'Set Environment', f'Env vars have been set to {solution}')

--- a/src/badger/gui/default/components/run_monitor.py
+++ b/src/badger/gui/default/components/run_monitor.py
@@ -814,9 +814,13 @@ class BadgerOptMonitor(QWidget):
         reply = QMessageBox.question(
             self,
             "Apply Solution",
-            f"Are you sure you want to apply the selected solution:\n"
-            + "\n".join(f"{variable_names[i]}: {round(curr_vars[i],3)} -> {round(solution[i],3)}," for i in range(len(variable_names)))
-            + "\nto " + f"{self.routine.environment.name}?",
+            "Are you sure you want to apply the selected solution:\n"
+            + "\n".join(
+                f"{variable_names[i]}: {round(curr_vars[i],3)} -> {round(solution[i],3)},"
+                for i in range(len(variable_names))
+            )
+            + "\nto "
+            + f"{self.routine.environment.name}?",
             QMessageBox.Yes | QMessageBox.No,
             QMessageBox.No,
         )


### PR DESCRIPTION
Two changes:

- Slight modification to status messages for dialing in solution
  - Added more descriptive popup message confirming [device: prev value -> new value], rather than just a list of new values to be set
- Updated behavior of set_options_from_template so that:
  -  If relative_to_current is True, variable scan ranges will be set relative to current values (based on vrange_limit_options). If relative_to_current is false they will be set to the values saved in the template.
  - Initial points table will be filled even when "automatic" is not checked, based on init_point_actions saved in template
  - Check for vars_env and env_name before calling associated functions. (This avoids error popups if an environment is not selected in the template)