### PR TITLE
Set variable range limit patch

### DIFF
--- a/src/badger/gui/acr/components/routine_page.py
+++ b/src/badger/gui/acr/components/routine_page.py
@@ -1009,11 +1009,12 @@ class BadgerRoutinePage(QWidget):
         # By default update all variables no matter if selected or not
         vname_selected = []
         vrange = {}
-        
+
         if set_all:
+            # Set vranges for all variables
             _variables = self.env_box.var_table.variables
         else:
-            # Only set vranges to the visible variables
+            # Only set vranges for the visible variables
             _variables = self.env_box.var_table.get_visible_variables(
                 self.env_box.var_table.variables
             )

--- a/src/badger/gui/acr/components/routine_page.py
+++ b/src/badger/gui/acr/components/routine_page.py
@@ -109,7 +109,8 @@ class BadgerRoutinePage(QWidget):
         self.env_box.relative_to_curr.setChecked(True)
 
         # Template path
-        self.template_dir = os.path.join(self.BADGER_PLUGIN_ROOT, "templates")
+        self.template_dir = "/home/physics/badger/cu_hxr/plugins/templates"
+        # self.template_dir = os.path.join(self.BADGER_PLUGIN_ROOT, "templates")
         # self.template_dir = "/home/physics/mlans/workspace/badger_test/Badger/src/badger/built_in_plugins/templates"
 
     def init_ui(self):
@@ -1010,11 +1011,14 @@ class BadgerRoutinePage(QWidget):
         # By default update all variables no matter if selected or not
         vname_selected = []
         vrange = {}
-
-        # Only set vranges to the visible variables
-        _variables = self.env_box.var_table.get_visible_variables(
-            self.env_box.var_table.variables
-        )
+        
+        if set_all:
+            _variables = self.env_box.var_table.variables
+        else:
+            # Only set vranges to the visible variables
+            _variables = self.env_box.var_table.get_visible_variables(
+                self.env_box.var_table.variables
+            )
 
         for var in _variables:
             name = next(iter(var))

--- a/src/badger/gui/acr/components/routine_page.py
+++ b/src/badger/gui/acr/components/routine_page.py
@@ -108,9 +108,6 @@ class BadgerRoutinePage(QWidget):
         # Trigger the re-rendering of the environment box
         self.env_box.relative_to_curr.setChecked(True)
 
-        # Template path
-        self.template_dir = os.path.join(self.BADGER_PLUGIN_ROOT, "templates")
-
     def init_ui(self):
         config_singleton = init_settings()
 
@@ -234,6 +231,12 @@ class BadgerRoutinePage(QWidget):
         tabs.setCurrentIndex(1)  # Show the env box by default
 
         # vbox.addStretch()
+
+        # Template path
+        try:
+            self.template_dir = config_singleton.read_value("BADGER_TEMPLATE_ROOT")
+        except KeyError:
+            self.template_dir = os.path.join(self.BADGER_PLUGIN_ROOT, "templates")
 
     def config_logic(self):
         self.btn_descr_update.clicked.connect(self.update_description)
@@ -442,12 +445,11 @@ class BadgerRoutinePage(QWidget):
 
         # Filter generator
         generator_name = self.generator_box.cb.currentText()
-        # generator_config = load_config(self.generator_box.edit.toPlainText())
 
         generator_config = self._filter_generator_params(
-            generator_name = generator_name,
-            generator_config = load_config(self.generator_box.edit.toPlainText()),
-            )
+            generator_name=generator_name,
+            generator_config=load_config(self.generator_box.edit.toPlainText()),
+        )
 
         template_dict = {
             "name": self.edit_save.text(),
@@ -488,7 +490,7 @@ class BadgerRoutinePage(QWidget):
                     for k, v in turbo.items()
                     if k in {"name", "length", "length_max", "length_min"}
                 }
-        
+
         return generator_config
 
     def save_template_yaml(self):

--- a/src/badger/gui/acr/components/routine_page.py
+++ b/src/badger/gui/acr/components/routine_page.py
@@ -109,9 +109,7 @@ class BadgerRoutinePage(QWidget):
         self.env_box.relative_to_curr.setChecked(True)
 
         # Template path
-        self.template_dir = "/home/physics/badger/cu_hxr/plugins/templates"
-        # self.template_dir = os.path.join(self.BADGER_PLUGIN_ROOT, "templates")
-        # self.template_dir = "/home/physics/mlans/workspace/badger_test/Badger/src/badger/built_in_plugins/templates"
+        self.template_dir = os.path.join(self.BADGER_PLUGIN_ROOT, "templates")
 
     def init_ui(self):
         config_singleton = init_settings()

--- a/src/badger/gui/acr/components/routine_page.py
+++ b/src/badger/gui/acr/components/routine_page.py
@@ -442,22 +442,12 @@ class BadgerRoutinePage(QWidget):
 
         # Filter generator
         generator_name = self.generator_box.cb.currentText()
-        generator_config = load_config(self.generator_box.edit.toPlainText())
+        # generator_config = load_config(self.generator_box.edit.toPlainText())
 
-
-        if generator_name == "expected_improvement":
-            # Filter turbo_controller
-            if (
-                "turbo_controller" in generator_config
-                and generator_config["turbo_controller"] is not None
-            ):
-                turbo = generator_config["turbo_controller"]
-                # Only keep selected keys
-                generator_config["turbo_controller"] = {
-                    k: v
-                    for k, v in turbo.items()
-                    if k in {"name", "length", "length_max", "length_min"}
-                }
+        generator_config = self._filter_generator_params(
+            generator_name = generator_name,
+            generator_config = load_config(self.generator_box.edit.toPlainText()),
+            )
 
         template_dict = {
             "name": self.edit_save.text(),
@@ -482,6 +472,24 @@ class BadgerRoutinePage(QWidget):
         }
 
         return template_dict
+
+    def _filter_generator_params(self, generator_name: str, generator_config: dict):
+        """
+        Filter which generator parameters get saved to template
+        """
+        if generator_name == "expected_improvement":
+            if (
+                "turbo_controller" in generator_config
+                and generator_config["turbo_controller"] is not None
+            ):
+                turbo = generator_config["turbo_controller"]
+                generator_config["turbo_controller"] = {
+                    k: v
+                    for k, v in turbo.items()
+                    if k in {"name", "length", "length_max", "length_min"}
+                }
+        
+        return generator_config
 
     def save_template_yaml(self):
         """

--- a/src/badger/gui/default/components/run_monitor.py
+++ b/src/badger/gui/default/components/run_monitor.py
@@ -815,7 +815,7 @@ class BadgerOptMonitor(QWidget):
             self,
             "Apply Solution",
             f"Are you sure you want to apply the selected solution:\n"
-            + "\n".join(f"{variable_names[i]}: {round(curr_vars[i],3)} -> {solution[i]}," for i in range(len(variable_names)))
+            + "\n".join(f"{variable_names[i]}: {round(curr_vars[i],3)} -> {round(solution[i],3)}," for i in range(len(variable_names)))
             + "\nto " + f"{self.routine.environment.name}?",
             QMessageBox.Yes | QMessageBox.No,
             QMessageBox.No,
@@ -831,7 +831,7 @@ class BadgerOptMonitor(QWidget):
 
         updated_vars = get_current_vars(self.routine)
         self.sig_status.emit(
-            f"Dial in solution: Env vars {curr_vars} -> {updated_vars}"
+            f"Dial in solution: {[f'{variable_names[i]}: {round(curr_vars[i],4)} -> {round(updated_vars[i],4)}' for i in range(len(variable_names))]}"
         )
         # QMessageBox.information(
         #     self, 'Set Environment', f'Env vars have been set to {solution}')

--- a/src/badger/gui/default/components/run_monitor.py
+++ b/src/badger/gui/default/components/run_monitor.py
@@ -814,9 +814,13 @@ class BadgerOptMonitor(QWidget):
         reply = QMessageBox.question(
             self,
             "Apply Solution",
-            f"Are you sure you want to apply the selected solution:\n"
-            + "\n".join(f"{variable_names[i]}: {round(curr_vars[i],3)} -> {round(solution[i],3)}," for i in range(len(variable_names)))
-            + "\nto " + f"{self.routine.environment.name}?",
+            "Are you sure you want to apply the selected solution:\n"
+            + "\n".join(
+                f"{variable_names[i]}: {round(curr_vars[i],3)} -> {round(solution[i],3)},"
+                for i in range(len(variable_names))
+            )
+            + "\nto "
+            + f"{self.routine.environment.name}?",
             QMessageBox.Yes | QMessageBox.No,
             QMessageBox.No,
         )

--- a/src/badger/gui/default/windows/lim_vrange_dialog.py
+++ b/src/badger/gui/default/windows/lim_vrange_dialog.py
@@ -7,6 +7,7 @@ from PyQt5.QtWidgets import (
     QPushButton,
     QVBoxLayout,
     QDoubleSpinBox,
+    QRadioButton,
 )
 from PyQt5.QtWidgets import (
     QGroupBox,
@@ -126,6 +127,19 @@ will be clipped by the variable range."""
         stacks.setCurrentIndex(self.configs["limit_option_idx"])
         vbox_config.addWidget(stacks)
         vbox_config.addStretch(1)
+        
+        # Apply to group
+        apply_to_group = QWidget()
+        hbox_apply_to = QHBoxLayout(apply_to_group)
+        hbox_apply_to.setContentsMargins(0, 0, 0, 0)
+        lbl_apply_to = QLabel("Apply to:")
+        self.rb_all_variables = rb_all_variables = QRadioButton("All Variables")
+        self.rb_only_visible = rb_only_visible = QRadioButton("Only Visible")
+        rb_all_variables.setChecked(True) # Default selection
+        hbox_apply_to.addWidget(lbl_apply_to)
+        hbox_apply_to.addWidget(rb_all_variables)
+        hbox_apply_to.addWidget(rb_only_visible)
+        vbox_config.addWidget(apply_to_group)
 
         # Button set
         button_set = QWidget()
@@ -146,7 +160,9 @@ will be clipped by the variable range."""
     def config_logic(self):
         self.cb.currentIndexChanged.connect(self.limit_option_changed)
         self.btn_cancel.clicked.connect(self.close)
-        self.btn_set.clicked.connect(self.set)
+        self.btn_set.clicked.connect(
+            lambda: self.set(set_all=self.rb_all_variables.isChecked())
+        )
         self.sb_ratio_curr.valueChanged.connect(self.ratio_curr_changed)
         self.sb_ratio_full.valueChanged.connect(self.ratio_full_changed)
         self.sb_delta.valueChanged.connect(self.delta_changed)
@@ -160,9 +176,9 @@ will be clipped by the variable range."""
     def delta_changed(self, delta):
         self.configs["delta"] = delta
 
-    def set(self):
+    def set(self, set_all: bool):
         self.save_config(self.configs)
-        self.set_vrange()
+        self.set_vrange(set_all=set_all)
         self.close()
 
     def limit_option_changed(self, i):

--- a/src/badger/gui/default/windows/lim_vrange_dialog.py
+++ b/src/badger/gui/default/windows/lim_vrange_dialog.py
@@ -135,7 +135,7 @@ will be clipped by the variable range."""
         lbl_apply_to = QLabel("Apply to:")
         self.rb_all_variables = rb_all_variables = QRadioButton("All Variables")
         self.rb_only_visible = rb_only_visible = QRadioButton("Only Visible")
-        rb_all_variables.setChecked(True) # Default selection
+        rb_all_variables.setChecked(True)  # Default selection
         hbox_apply_to.addWidget(lbl_apply_to)
         hbox_apply_to.addWidget(rb_all_variables)
         hbox_apply_to.addWidget(rb_only_visible)
@@ -178,7 +178,7 @@ will be clipped by the variable range."""
 
     def set(self, set_all: bool = True):
         self.save_config(self.configs)
-        self.set_vrange(set_all=set_all)
+        self.set_vrange(set_all=set_all)  # pass set_all flag to set_vrange
         self.close()
 
     def limit_option_changed(self, i):

--- a/src/badger/gui/default/windows/lim_vrange_dialog.py
+++ b/src/badger/gui/default/windows/lim_vrange_dialog.py
@@ -127,7 +127,7 @@ will be clipped by the variable range."""
         stacks.setCurrentIndex(self.configs["limit_option_idx"])
         vbox_config.addWidget(stacks)
         vbox_config.addStretch(1)
-        
+
         # Apply to group
         apply_to_group = QWidget()
         hbox_apply_to = QHBoxLayout(apply_to_group)
@@ -176,7 +176,7 @@ will be clipped by the variable range."""
     def delta_changed(self, delta):
         self.configs["delta"] = delta
 
-    def set(self, set_all: bool):
+    def set(self, set_all: bool = True):
         self.save_config(self.configs)
         self.set_vrange(set_all=set_all)
         self.close()
@@ -189,6 +189,6 @@ will be clipped by the variable range."""
 
     def keyPressEvent(self, event):
         if event.key() == Qt.Key_Return or event.key() == Qt.Key_Enter:
-            self.set()
+            self.set(set_all=self.rb_all_variables.isChecked())
         elif event.key() == Qt.Key_Escape:
             self.close()


### PR DESCRIPTION
A few changes:

1. Improved setting variable range limit behavior in GUI
    - Dialog popup now gives user the option to apply limit changes to all variables or only visible
    - Updated set_vrange() in routine_page.py to support a set_all flag (default: True) to control this behavior
    - Updated vrange_lim_dialog to include a radiobutton option for specifying the scope of limit changes (visible vs. all)
2. Template Generation: Filter turbo controller parameters
    - Added _filter_generator_params() to exclude run-specific turbo_controller paramters (e.g., best_point) from being saved in templates
    - When saving a template with expected_improvement with turbo_controller, only general parameters (name, length-scale) are saved to template
3. Template Directory path handling
    - Changed logic for locating template directory:
      - Now prioritizes BADGER_TEMPLATE_ROOT over BADGER_PLUGIN_ROOT for templates
      - Falls back to BADGER_PLUGIN_ROOT if BADGER_TEMPLATE_ROOT is not set