### PR TITLE
Add template root to Badger settings

### DIFF
--- a/src/badger/actions/__init__.py
+++ b/src/badger/actions/__init__.py
@@ -35,7 +35,7 @@ def show_info(args):
 
     config_singleton = init_settings()
     BADGER_PLUGIN_ROOT = config_singleton.read_value("BADGER_PLUGIN_ROOT")
-    # BADGER_DB_ROOT = config_singleton.read_value("BADGER_DB_ROOT")
+    BADGER_TEMPLATE_ROOT = config_singleton.read_value("BADGER_TEMPLATE_ROOT")
     BADGER_LOGBOOK_ROOT = config_singleton.read_value("BADGER_LOGBOOK_ROOT")
     BADGER_ARCHIVE_ROOT = config_singleton.read_value("BADGER_ARCHIVE_ROOT")
 
@@ -44,7 +44,7 @@ def show_info(args):
         "version": metadata.version("badger-opt"),
         "xopt version": metadata.version("xopt"),
         "plugin root": BADGER_PLUGIN_ROOT,
-        # "database root": BADGER_DB_ROOT,
+        "template root": BADGER_TEMPLATE_ROOT,
         "logbook root": BADGER_LOGBOOK_ROOT,
         "archive root": BADGER_ARCHIVE_ROOT,
         # 'plugin installation url': read_value('BADGER_PLUGINS_URL')

--- a/src/badger/gui/acr/components/routine_page.py
+++ b/src/badger/gui/acr/components/routine_page.py
@@ -1041,7 +1041,7 @@ class BadgerRoutinePage(QWidget):
 
         if set_all:
             # Set vranges for all variables
-            _variables = self.env_box.var_table.variables
+            _variables = self.env_box.var_table.all_variables
         else:
             # Only set vranges for the visible variables
             _variables = self.env_box.var_table.get_visible_variables(
@@ -1050,9 +1050,10 @@ class BadgerRoutinePage(QWidget):
 
         for var in _variables:
             name = next(iter(var))
-            if set_all or self.env_box.var_table.is_checked(name):
-                vname_selected.append(name)
-                vrange[name] = var[name]
+            # Set vrange no matter if selected or not
+            # if set_all or self.env_box.var_table.is_checked(name):
+            vname_selected.append(name)
+            vrange[name] = var[name]
 
         env = self.create_env()
         var_curr = env._get_variables(vname_selected)

--- a/src/badger/gui/acr/windows/settings_dialog.py
+++ b/src/badger/gui/acr/windows/settings_dialog.py
@@ -66,6 +66,14 @@ class BadgerSettingsDialog(QDialog):
         grid.addWidget(plugin_root, 1, 0)
         grid.addWidget(plugin_root_path, 1, 1)
 
+        # Template Root
+        self.template_root = template_root = QLabel("Template Root")
+        self.template_root_path = template_root_path = QLineEdit(
+            self.config_singleton.read_value("BADGER_TEMPLATE_ROOT")
+        )
+        grid.addWidget(template_root, 2, 0)
+        grid.addWidget(template_root_path, 2, 1)
+
         # Logbook Root
         self.logbook_root = logbook_root = QLabel("Logbook Root")
         self.logbook_root_path = logbook_root_path = QLineEdit(
@@ -162,6 +170,9 @@ class BadgerSettingsDialog(QDialog):
         self.accept()
         self.config_singleton.write_value(
             "BADGER_PLUGIN_ROOT", self.plugin_root_path.text()
+        )
+        self.config_singleton.write_value(
+            "BADGER_TEMPLATE_ROOT", self.template_root_path.text()
         )
         self.config_singleton.write_value(
             "BADGER_LOGBOOK_ROOT", self.logbook_root_path.text()

--- a/src/badger/settings.py
+++ b/src/badger/settings.py
@@ -40,8 +40,8 @@ class BadgerConfig(BaseModel):
     ----------
     BADGER_PLUGIN_ROOT : Setting
         Setting for the plugin root directory.
-    BADGER_DB_ROOT : Setting
-        Setting for the database root directory.
+    BADGER_TEMPLATE_ROOT : Setting
+        Setting for the template root directory.
     BADGER_LOGBOOK_ROOT : Setting
         Setting for the logbook root directory.
     BADGER_ARCHIVE_ROOT : Setting
@@ -60,9 +60,9 @@ class BadgerConfig(BaseModel):
         value=None,
         is_path=True,
     )
-    BADGER_DB_ROOT: Setting = Setting(
-        display_name="database root",
-        description="This setting (BADGER_DB_ROOT) tells Badger where to store the routine database",
+    BADGER_TEMPLATE_ROOT: Setting = Setting(
+        display_name="template root",
+        description="This setting (BADGER_TEMPLATE_ROOT) tells Badger where to store the routine templates",
         value=None,
         is_path=True,
     )

--- a/src/badger/tests/conftest.py
+++ b/src/badger/tests/conftest.py
@@ -13,7 +13,7 @@ def suppress_popups(mocker):
 
 @pytest.fixture(scope="module", autouse=True)
 def config_test_settings(
-    mock_plugin_root, mock_db_root, mock_logbook_root, mock_archive_root
+    mock_plugin_root, mock_template_root, mock_logbook_root, mock_archive_root
 ):
     from badger.settings import init_settings
 
@@ -21,13 +21,13 @@ def config_test_settings(
 
     # Store the old values
     old_root = config_singleton.read_value("BADGER_PLUGIN_ROOT")
-    old_db = config_singleton.read_value("BADGER_DB_ROOT")
+    old_template = config_singleton.read_value("BADGER_TEMPLATE_ROOT")
     old_logbook = config_singleton.read_value("BADGER_LOGBOOK_ROOT")
     old_archived = config_singleton.read_value("BADGER_ARCHIVE_ROOT")
 
     # Assign values for test
     config_singleton.write_value("BADGER_PLUGIN_ROOT", mock_plugin_root)
-    config_singleton.write_value("BADGER_DB_ROOT", mock_db_root)
+    config_singleton.write_value("BADGER_TEMPLATE_ROOT", mock_template_root)
     config_singleton.write_value("BADGER_LOGBOOK_ROOT", mock_logbook_root)
     config_singleton.write_value("BADGER_ARCHIVE_ROOT", mock_archive_root)
 
@@ -35,22 +35,22 @@ def config_test_settings(
 
     # Restoring the original settings
     config_singleton.write_value("BADGER_PLUGIN_ROOT", old_root)
-    config_singleton.write_value("BADGER_DB_ROOT", old_db)
+    config_singleton.write_value("BADGER_TEMPLATE_ROOT", old_template)
     config_singleton.write_value("BADGER_LOGBOOK_ROOT", old_logbook)
     config_singleton.write_value("BADGER_ARCHIVE_ROOT", old_archived)
 
 
 @pytest.fixture(scope="module", autouse=True)
-def clean_up(mock_db_root, mock_logbook_root, mock_archive_root):
+def clean_up(mock_template_root, mock_logbook_root, mock_archive_root):
     # Clean before tests
-    shutil.rmtree(mock_db_root, True)  # ignore errors
+    shutil.rmtree(mock_template_root, True)  # ignore errors
     shutil.rmtree(mock_logbook_root, True)
     shutil.rmtree(mock_archive_root, True)
 
     yield
 
     # Clean after tests
-    shutil.rmtree(mock_db_root, True)
+    shutil.rmtree(mock_template_root, True)
     shutil.rmtree(mock_logbook_root, True)
     shutil.rmtree(mock_archive_root, True)
 
@@ -66,8 +66,8 @@ def mock_plugin_root(mock_root):
 
 
 @pytest.fixture(scope="module")
-def mock_db_root(mock_root):
-    return os.path.join(mock_root, "db")
+def mock_template_root(mock_root):
+    return os.path.join(mock_root, "templates")
 
 
 @pytest.fixture(scope="module")

--- a/src/badger/tests/test_cli_basic.py
+++ b/src/badger/tests/test_cli_basic.py
@@ -18,7 +18,7 @@ def test_cli_main():
 
     # Check output lines
     outlines = out.splitlines()
-    assert len(outlines) == 6
+    assert len(outlines) == 7
 
     # Check name
     assert outlines[0] == "name: Badger the optimizer"

--- a/src/badger/tests/test_settings.py
+++ b/src/badger/tests/test_settings.py
@@ -23,10 +23,10 @@ class TestBadgerConfig:
                 value="/mock/plugin/root",
                 is_path=True,
             ),
-            BADGER_DB_ROOT=Setting(
-                display_name="database root",
-                description="Mock database root",
-                value="/mock/db/root",
+            BADGER_TEMPLATE_ROOT=Setting(
+                display_name="template root",
+                description="Mock template root",
+                value="/mock/template/root",
                 is_path=True,
             ),
             BADGER_LOGBOOK_ROOT=Setting(
@@ -127,7 +127,10 @@ class TestBadgerConfig:
                     config_singleton.config.BADGER_PLUGIN_ROOT.value
                     == "/mock/plugin/root"
                 )
-                assert config_singleton.config.BADGER_DB_ROOT.value == "/mock/db/root"
+                assert (
+                    config_singleton.config.BADGER_TEMPLATE_ROOT.value
+                    == "/mock/template/root"
+                )
 
     def test_config_singleton_create_new_config_if_not_exists(self):
         with patch("os.path.exists", return_value=False):

--- a/src/badger/tests/utils.py
+++ b/src/badger/tests/utils.py
@@ -188,6 +188,11 @@ def get_vars_in_row(routine, idx=0):
 
 
 def fix_path_issues():
+    from badger.settings import init_settings
     from badger.archive import BADGER_ARCHIVE_ROOT
 
+    config_singleton = init_settings()
+    BADGER_TEMPLATE_ROOT = config_singleton.read_value("BADGER_TEMPLATE_ROOT")
+
     os.makedirs(BADGER_ARCHIVE_ROOT, exist_ok=True)
+    os.makedirs(BADGER_TEMPLATE_ROOT, exist_ok=True)


### PR DESCRIPTION
Also fixed a few global set vrange issues. Current behavior:

- If set all: set to all the variables defined in env and in routine (`additional_variables`)
- If set only visible: set to all the visible variables in the variable table

Variable check status doesn't affect set vrange behavior (or should it?)