### PR TITLE
patch for turbo_parameter filtering and set variable ranges

### DIFF
--- a/src/badger/gui/acr/components/routine_page.py
+++ b/src/badger/gui/acr/components/routine_page.py
@@ -479,7 +479,7 @@ class BadgerRoutinePage(QWidget):
         """
         Filter which generator parameters get saved to template
         """
-        if generator_name == "expected_improvement":
+        if generator_name in ["expected_improvement", "upper_confidence_bound"]:
             if (
                 "turbo_controller" in generator_config
                 and generator_config["turbo_controller"] is not None
@@ -488,7 +488,17 @@ class BadgerRoutinePage(QWidget):
                 generator_config["turbo_controller"] = {
                     k: v
                     for k, v in turbo.items()
-                    if k in {"name", "length", "length_max", "length_min"}
+                    if k
+                    in {
+                        "name",
+                        "length",
+                        "length_max",
+                        "length_min",
+                        "failure_tolerance",
+                        "success_tolerance",
+                        "scale_factor",
+                        "restrict_model_data",
+                    }
                 }
 
         return generator_config

--- a/src/badger/gui/acr/components/routine_page.py
+++ b/src/badger/gui/acr/components/routine_page.py
@@ -108,6 +108,7 @@ class BadgerRoutinePage(QWidget):
         # Trigger the re-rendering of the environment box
         self.env_box.relative_to_curr.setChecked(True)
         # remember user selection from lim_vrange_dialog gui
+        # 2: not initialized, 1: apply to all, 0: apply to only visible
         self.lim_apply_to_vars = 2
 
     def init_ui(self):

--- a/src/badger/gui/acr/components/routine_page.py
+++ b/src/badger/gui/acr/components/routine_page.py
@@ -108,9 +108,6 @@ class BadgerRoutinePage(QWidget):
         # Trigger the re-rendering of the environment box
         self.env_box.relative_to_curr.setChecked(True)
 
-        # Template path
-        self.template_dir = os.path.join(self.BADGER_PLUGIN_ROOT, "templates")
-
     def init_ui(self):
         config_singleton = init_settings()
 
@@ -234,6 +231,12 @@ class BadgerRoutinePage(QWidget):
         tabs.setCurrentIndex(1)  # Show the env box by default
 
         # vbox.addStretch()
+
+        # Template path
+        try:
+            self.template_dir = config_singleton.read_value("BADGER_TEMPLATE_ROOT")
+        except KeyError:
+            self.template_dir = os.path.join(self.BADGER_PLUGIN_ROOT, "templates")
 
     def config_logic(self):
         self.btn_descr_update.clicked.connect(self.update_description)
@@ -442,12 +445,11 @@ class BadgerRoutinePage(QWidget):
 
         # Filter generator
         generator_name = self.generator_box.cb.currentText()
-        # generator_config = load_config(self.generator_box.edit.toPlainText())
 
         generator_config = self._filter_generator_params(
-            generator_name = generator_name,
-            generator_config = load_config(self.generator_box.edit.toPlainText()),
-            )
+            generator_name=generator_name,
+            generator_config=load_config(self.generator_box.edit.toPlainText()),
+        )
 
         template_dict = {
             "name": self.edit_save.text(),
@@ -488,7 +490,7 @@ class BadgerRoutinePage(QWidget):
                     for k, v in turbo.items()
                     if k in {"name", "length", "length_max", "length_min"}
                 }
-        
+
         return generator_config
 
     def save_template_yaml(self):

--- a/src/badger/gui/acr/components/routine_page.py
+++ b/src/badger/gui/acr/components/routine_page.py
@@ -636,7 +636,7 @@ class BadgerRoutinePage(QWidget):
         all_variables = dict(sorted(all_variables.items()))
         all_variables = [{key: value} for key, value in all_variables.items()]
 
-        self.env_box.var_table.update_variables(all_variables)
+        self.env_box.var_table.update_variables(variables=all_variables, filtered=2)
         self.env_box.var_table.set_selected(variables)
         self.env_box.var_table.addtl_vars = routine.additional_variables
 

--- a/src/badger/gui/acr/components/routine_page.py
+++ b/src/badger/gui/acr/components/routine_page.py
@@ -107,6 +107,8 @@ class BadgerRoutinePage(QWidget):
 
         # Trigger the re-rendering of the environment box
         self.env_box.relative_to_curr.setChecked(True)
+        # remember user selection from lim_vrange_dialog gui
+        self.lim_apply_to_vars = 2
 
     def init_ui(self):
         config_singleton = init_settings()
@@ -1037,11 +1039,16 @@ class BadgerRoutinePage(QWidget):
         # dlg.exec()
 
     def limit_variable_ranges(self):
+        if self.lim_apply_to_vars == 2:
+            # Initialize the lim_apply_to_vars to 0 (set only visible vars)
+            self.lim_apply_to_vars = 0
+
         dlg = BadgerLimitVariableRangeDialog(
             self,
             self.set_vrange,
             self.save_limit_option,
             self.limit_option,
+            self.lim_apply_to_vars,
         )
         dlg.exec()
 
@@ -1101,6 +1108,12 @@ class BadgerRoutinePage(QWidget):
         self.env_box.var_table.set_bounds(vrange)
         self.clear_init_table(reset_actions=False)  # clear table after changing ranges
         self.update_init_table()  # auto populate if option is set
+
+        # remember user selection for applying limit changes
+        if not self.lim_apply_to_vars == 2:
+            # Check if lim_apply_to_vars has been initialized
+            # It will be set to 2 until the btn_lim_vrange is clicked
+            self.lim_apply_to_vars = set_all
 
         # Record the ratio var ranges
         for vname in vname_selected:

--- a/src/badger/gui/acr/components/routine_page.py
+++ b/src/badger/gui/acr/components/routine_page.py
@@ -483,6 +483,7 @@ class BadgerRoutinePage(QWidget):
             if (
                 "turbo_controller" in generator_config
                 and generator_config["turbo_controller"] is not None
+                and isinstance(generator_config["turbo_controller"], dict)
             ):
                 turbo = generator_config["turbo_controller"]
                 generator_config["turbo_controller"] = {

--- a/src/badger/gui/default/windows/lim_vrange_dialog.py
+++ b/src/badger/gui/default/windows/lim_vrange_dialog.py
@@ -20,7 +20,9 @@ from PyQt5.QtCore import Qt
 
 
 class BadgerLimitVariableRangeDialog(QDialog):
-    def __init__(self, parent, set_vrange, save_config, configs=None):
+    def __init__(
+        self, parent, set_vrange, save_config, configs=None, apply_to_all=False
+    ):
         super().__init__(parent)
 
         self.set_vrange = set_vrange
@@ -33,6 +35,7 @@ class BadgerLimitVariableRangeDialog(QDialog):
                 "ratio_full": 0.1,
                 "delta": 0.1,
             }
+        self.apply_to_all = apply_to_all
 
         self.init_ui()
         self.config_logic()
@@ -135,7 +138,10 @@ will be clipped by the variable range."""
         lbl_apply_to = QLabel("Apply to:")
         self.rb_all_variables = rb_all_variables = QRadioButton("All Variables")
         self.rb_only_visible = rb_only_visible = QRadioButton("Only Visible")
-        rb_all_variables.setChecked(True)  # Default selection
+        if self.apply_to_all:
+            rb_all_variables.setChecked(True)
+        else:
+            rb_only_visible.setChecked(True)  # Default selection
         hbox_apply_to.addWidget(lbl_apply_to)
         hbox_apply_to.addWidget(rb_all_variables)
         hbox_apply_to.addWidget(rb_only_visible)


### PR DESCRIPTION
1. Improved turbo parameter filtering when saving templates
    - Include name, length, length_max, length_min, failure_tolerance, success_tolerance, scale_factor, restrict_model_data
    - Included upper_confidence_bound in algorithms to filter, alongside expected_improvement
2. Patch to not reset var_table ranges in table when stopping optimization run
3. Changed default set variable range selection to only visible; GUI remembers user selection in local session
    - Added lim_apply_to_vars flag to routine_page, which gets passed when lim_vrange_dialog is opened. Checks corresponding radiobutton on dialog panel.