### PR TITLE
Fix the wrong config file in subprocess issue

### DIFF
--- a/src/badger/core_subprocess.py
+++ b/src/badger/core_subprocess.py
@@ -5,12 +5,11 @@ import traceback
 from pandas import DataFrame
 import multiprocessing as mp
 
-from badger.archive import load_run
+from badger.settings import init_settings
 from badger.errors import BadgerRunTerminated, BadgerEnvObsError
 from badger.logger import _get_default_logger
 from badger.logger.event import Events
 from badger.routine import Routine
-from badger.archive import archive_run
 
 from xopt.errors import FeasibilityError, XoptError
 
@@ -72,6 +71,7 @@ def run_routine_subprocess(
     stop_process: mp.Event,
     pause_process: mp.Event,
     wait_event: mp.Event,
+    config_path: str = None,
 ) -> None:
     """
     Run the provided routine object using Xopt. This method is run as a subproccess
@@ -84,6 +84,12 @@ def run_routine_subprocess(
     pause_process: mp.Event
     wait_event: mp.Event
     """
+
+    # Initialize the settings singleton with the provided config path
+    init_settings(config_path)
+    # Now load the archive would use the correct config
+    from badger.archive import load_run, archive_run
+
     wait_event.wait()
 
     try:

--- a/src/badger/gui/default/components/create_process.py
+++ b/src/badger/gui/default/components/create_process.py
@@ -2,6 +2,7 @@ from multiprocessing import Event, Pipe, Process, Queue
 
 from PyQt5.QtCore import pyqtSignal, QObject
 
+from badger.settings import init_settings
 from badger.core_subprocess import run_routine_subprocess
 
 
@@ -27,6 +28,7 @@ class CreateProcess(QObject):
         self.data_queue = Queue()
         self.evaluate_queue = Pipe()
         self.wait_event = Event()
+        config_path = init_settings()._instance.config_path
 
         new_process = Process(
             target=run_routine_subprocess,
@@ -36,6 +38,7 @@ class CreateProcess(QObject):
                 self.stop_event,
                 self.pause_event,
                 self.wait_event,
+                config_path,
             ),
         )
         new_process.start()


### PR DESCRIPTION
### The issue

When launch Badger w/ config file other than the default one, running an optimization would fail due to tmp run file not found.

### Cause of the issue

In subprocess, it imports `archive.py` at the beginning, which calls `init_settings()` to get the config singleton. However since it's a new memory space (cause it's in a subprocess), the config singleton would be recreated w/ empty config path -- meaning it will read the default config file. The run logic is to combine the archive root w/ the tmp run filename to form the tmp run file to load, while the archive root in the subprocess is wrong (using the value of the default config), the routine runner would not be able to find the tmp run file.

### Solution

To resolve it, we need to pass the correct config path to subprocess and initialize the config singleton w/ it, then import `archive.py` after that to make sure `BADGER_ARCHIVE_ROOT` is read from the correct config.