### PR TITLE
Removed mouse wheel events from variable spinboxes

### DIFF
--- a/src/badger/gui/default/components/robust_spinbox.py
+++ b/src/badger/gui/default/components/robust_spinbox.py
@@ -38,8 +38,8 @@ class RobustSpinBox(QDoubleSpinBox):
         super().__init__(*args, **kwargs)
 
         self.setDecimals(decimals)
-        self.setFocusPolicy(Qt.StrongFocus)
+        self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         self.installEventFilter(MouseWheelWidgetAdjustmentGuard(self))
         self.setRange(lb, ub)
-        self.setStepType(QAbstractSpinBox.AdaptiveDecimalStepType)
+        self.setStepType(QAbstractSpinBox.StepType.AdaptiveDecimalStepType)
         self.setValue(default_value)

--- a/src/badger/gui/default/utils.py
+++ b/src/badger/gui/default/utils.py
@@ -1,6 +1,6 @@
 from importlib import resources
 from typing import Any
-from PyQt5.QtWidgets import QWidget, QAbstractSpinBox, QPushButton, QComboBox
+from PyQt5.QtWidgets import QAbstractSpinBox, QPushButton, QComboBox
 from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel
 from PyQt5.QtCore import Qt, QObject, QEvent, QSize
 from PyQt5.QtGui import QIcon
@@ -17,8 +17,8 @@ class MouseWheelWidgetAdjustmentGuard(QObject):
         super().__init__(parent)
 
     def eventFilter(self, o: QObject, e: QEvent) -> bool:
-        widget: QWidget = o
-        if e.type() == QEvent.Wheel and not widget.hasFocus():
+        # Ignore mouse wheel events for widget
+        if e.type() == QEvent.Wheel:
             e.ignore()
             return True
         return super().eventFilter(o, e)


### PR DESCRIPTION
To prevent accidental incrementation of variable ranges when using the mouse wheel to scroll through the page, I have changed the event filter on the custom spinbox widget to ignore all mouse scroll events.