### PR TITLE
Data panel and load data

### DIFF
--- a/src/badger/archive.py
+++ b/src/badger/archive.py
@@ -26,8 +26,11 @@ def archive_run(routine, states=None):
 
     data = routine.sorted_data
     data_dict = data.to_dict("list")
-    ts_float = data_dict["timestamp"][0]  # time of the first evaluated point
-    suffix = ts_float_to_str(ts_float, "lcls-fname")
+    if hasattr(routine, "creation_ts"):
+        suffix = routine.creation_ts
+    else:  # compatibility with old routines
+        ts_float = data_dict["timestamp"][0]  # time of the first evaluated point
+        suffix = ts_float_to_str(ts_float, "lcls-fname")
     tokens = suffix.split("-")
     first_level = tokens[0]
     second_level = f"{tokens[0]}-{tokens[1]}"

--- a/src/badger/gui/acr/components/data_panel.py
+++ b/src/badger/gui/acr/components/data_panel.py
@@ -230,19 +230,19 @@ class BadgerDataPanel(QWidget):
         data = data[reordered_cols]
         all_data = pd.concat([self.table_data, data], ignore_index=True)
 
-        self.update_table(self.data_table, all_data, vocs, info=self.info)
+        self.update_table(self.data_table, all_data, vocs)
 
-    def update_table(self, table, data=None, vocs=None, info: bool = False) -> None:
+    def update_table(self, table, data=None, vocs=None) -> None:
         """Call data_table's update_table method but make sure table_data stays updated"""
         self.table_data = data
-        update_table(table, data, vocs, info)
+        update_table(table, data, vocs)
 
     def get_data(self):
         return self.table_data
 
-    def get_data_as_dict(self, info=False) -> dict:
+    def get_data_as_dict(self) -> dict:
         data = get_table_content_as_dict(self.data_table)
-        if not info:
+        if not self.info:
             data = self.filter_metadata(data)
 
         return data
@@ -295,7 +295,7 @@ class BadgerDataPanel(QWidget):
             # All keys match, add selected routine data to table
             combined_data = pd.concat([self.table_data, data], ignore_index=True)
             self.update_table(
-                self.data_table, combined_data, routine.vocs, info=self.info
+                self.data_table, combined_data, routine.vocs
             )
 
     def load_data(self, routine):
@@ -312,7 +312,6 @@ class BadgerDataPanel(QWidget):
             self.data_table,
             data,
             routine.vocs,
-            info=self.info,
         )
 
     def reset_data_table(self):

--- a/src/badger/gui/acr/components/data_panel.py
+++ b/src/badger/gui/acr/components/data_panel.py
@@ -1,0 +1,323 @@
+from PyQt5.QtWidgets import (
+    QVBoxLayout,
+    QHBoxLayout,
+    QPushButton,
+    QWidget,
+    QMessageBox,
+)
+import pandas as pd
+from PyQt5.QtWidgets import QGroupBox, QCheckBox, QLabel
+from PyQt5.QtCore import Qt
+from badger.gui.default.components.data_table import (
+    update_table,
+    get_table_content_as_dict,
+)
+from badger.gui.default.components.data_table import (
+    data_table,
+)
+from badger.gui.default.windows.load_data_from_run_dialog import (
+    BadgerLoadDataFromRunDialog,
+)
+import yaml
+
+LABEL_WIDTH = 96
+
+stylesheet_data = """
+    #DataPanel {
+        border: 4px solid #4AB640;
+        border-radius: 4px;
+    }
+"""
+
+stylesheet_no_data = """
+    #DataPanel {
+        border: 4px solid #19232D;
+        border-radius: 4px;
+    }
+"""
+
+
+class BadgerDataPanel(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.parent = parent
+
+        # Set up ui
+        self.init_ui()
+
+        # DataFrame to keep track of data in table
+        self.table_data = pd.DataFrame()
+
+        self.selected_routine = None
+
+        # boolean indicating whether to show metadata in table
+        self.info = False
+
+    def init_ui(self):
+        """Initialize interface"""
+        vbox = QVBoxLayout(self)
+        vbox.setContentsMargins(8, 8, 8, 8)
+
+        # Panel for data table
+        panel_table = QWidget()
+        vbox_table = QVBoxLayout(panel_table)
+        vbox_table.setContentsMargins(0, 0, 0, 0)
+        title_label = QLabel("Run Data")
+        title_label.setStyleSheet(
+            """
+                background-color: #455364;
+                font-weight: bold;
+                padding: 4px;
+        """
+        )
+        title_label.setAlignment(Qt.AlignCenter)  # Center-align the title
+        vbox_table.addWidget(title_label, 0)
+        vbox.addWidget(panel_table)
+
+        # Data Table
+        self.data_table_widget = QWidget()
+        self.data_table_widget.setObjectName("DataPanel")
+        hbox_data_table = QHBoxLayout(self.data_table_widget)
+        hbox_data_table.setContentsMargins(0, 10, 0, 0)
+        self.data_table = data_table()
+        self.data_table.set_uneditable()
+        self.data_table.setMinimumHeight(200)
+        hbox_data_table.addWidget(self.data_table)
+        vbox.addWidget(self.data_table_widget)
+
+        # Add label, buttons for loading data and clear table
+        load_data_options = QWidget()
+        hbox_load_data_options = QHBoxLayout(load_data_options)
+        hbox_load_data_options.setContentsMargins(0, 0, 0, 0)
+
+        self.btn_load_data = QPushButton("Add Data")
+        self.btn_load_data.clicked.connect(self.load_from_dialog)
+        self.btn_load_data.setFixedSize(96, 24)
+        self.btn_reset_table = QPushButton("Clear Table")
+        self.btn_reset_table.clicked.connect(self.reset_data_table)
+        self.btn_reset_table.setFixedSize(96, 24)
+        hbox_load_data_options.addWidget(self.btn_load_data)
+        hbox_load_data_options.addWidget(self.btn_reset_table)
+        hbox_load_data_options.setAlignment(Qt.AlignLeft)
+        vbox.addWidget(load_data_options)
+
+        # Widget for data options
+        data_opts_config = QWidget()
+
+        data_vbox = QVBoxLayout(data_opts_config)
+        data_vbox.setContentsMargins(0, 0, 0, 0)
+
+        generator_group = QGroupBox("Data Options")
+        vbox_generator = QVBoxLayout(generator_group)
+        self.run_data_checkbox = QCheckBox("Load displayed data into routine")
+        self.run_data_checkbox.stateChanged.connect(self.indicate_add_data_to_routine)
+        self.init_points_checkbox = QCheckBox("Skip initial point sampling")
+        self.init_points_checkbox.setEnabled(False)
+
+        vbox_generator.addWidget(self.run_data_checkbox)
+        vbox_generator.addWidget(self.init_points_checkbox)
+
+        # Group
+        vbox.addWidget(data_opts_config)
+        vbox.addWidget(generator_group)
+
+    def load_from_dialog(self):
+        """
+        Verify that variables and objectives have been selected, then open dialog to load data
+        """
+        vocs_str = self.parent._compose_vocs()[0].as_yaml()
+        vocs = yaml.safe_load(vocs_str)
+
+        if not vocs["variables"] or not vocs["objectives"]:
+            dialog = QMessageBox(
+                text=str("Select Environment + VOCS before adding data!"),
+                parent=self,
+            )
+            dialog.setIcon(QMessageBox.Information)
+            dialog.setStandardButtons(QMessageBox.Ok)
+            _ = dialog.exec_()
+
+            return
+        else:
+            _ = self.get_data_from_dialog()
+
+    def set_routine(self, routine):
+        self.selected_routine = routine
+
+    def indicate_add_data_to_routine(self):
+        """
+        This function indicates visually whether the displayed data will be loaded into the routine,
+        by placing a green border around the data table.
+        """
+        if self.run_data_checkbox.isChecked():
+            self.data_table_widget.setStyleSheet(stylesheet_data)
+            self.init_points_checkbox.setEnabled(True)
+        else:
+            self.data_table_widget.setStyleSheet(stylesheet_no_data)
+            self.init_points_checkbox.setChecked(False)
+            self.init_points_checkbox.setEnabled(False)
+
+    @property
+    def use_data(self) -> bool:
+        return self.run_data_checkbox.isChecked()
+
+    @property
+    def init_points(self) -> bool:
+        # Apologies for double negative, should probably be called skip_init_points_checkbox
+        return not self.init_points_checkbox.isChecked()
+
+    @property
+    def has_data(self) -> bool:
+        table_as_dict = get_table_content_as_dict(self.data_table)
+        return bool(table_as_dict)
+
+    def get_data_from_dialog(self):
+        """
+        Opens a dialog window for loading data into generator.
+        """
+        dlg = BadgerLoadDataFromRunDialog(
+            parent=self,
+            data_table=self.data_table,
+            on_set=self.load_data_from_dialog,
+        )
+        self.tc_dialog = dlg
+        try:
+            dlg.exec()
+        finally:
+            self.tc_dialog = None
+
+    def add_live_data(self, data):
+        """
+        Add datapoint from optimization run. This function expects a DataFrame as its argument. It first reorders
+        the columns to maintain consistency with any existing data. It then concatenates any existing data with
+        the new dataframe, and updates the table.
+
+        Arguments:
+            data (DataFrame): dataframe containing new data to be added
+        """
+
+        if not self.selected_routine:
+            print("no routine selected")
+            return
+
+        # reorder data columns to display on table
+        vocs = self.selected_routine.vocs
+        columns = list(data.columns)
+        reordered_cols = []
+
+        # objectives, timestamp, constraints, variables, observables
+        for obj_name in vocs.objective_names:
+            if obj_name in columns:
+                reordered_cols.append(obj_name)
+        reordered_cols.append("timestamp")
+        for con_name in vocs.constraint_names:
+            if con_name in columns and con_name not in reordered_cols:
+                # add to table but avoid duplicate cols
+                reordered_cols.append(con_name)
+        for var_name in vocs.variable_names:
+            if var_name in columns:
+                reordered_cols.append(var_name)
+        for sta_name in vocs.observable_names:
+            if sta_name in columns and sta_name not in reordered_cols:
+                # add to table but avoid duplicate cols
+                reordered_cols.append(sta_name)
+
+        # other metadata (xopt_runtime, xopt_error)
+        reordered_cols.extend(["xopt_error", "xopt_runtime"])
+        additional_cols = list(set(columns) - set(reordered_cols))
+        reordered_cols.extend(additional_cols)
+
+        data = data[reordered_cols]
+        all_data = pd.concat([self.table_data, data], ignore_index=True)
+
+        self.update_table(self.data_table, all_data, vocs, info=self.info)
+
+    def update_table(self, table, data=None, vocs=None, info: bool = False) -> None:
+        """Call data_table's update_table method but make sure table_data stays updated"""
+        self.table_data = data
+        update_table(table, data, vocs, info)
+
+    def get_data(self):
+        return self.table_data
+
+    def get_data_as_dict(self, info=False) -> dict:
+        data = get_table_content_as_dict(self.data_table)
+        if not info:
+            data = self.filter_metadata(data)
+
+        return data
+
+    def filter_metadata(self, data: dict) -> dict:
+        """
+        Remove metadata columns from dictionary
+        """
+        metadata_cols = ["xopt_runtime", "xopt_error", "timestamp", "source"]
+        cols_to_drop = [col for col in metadata_cols if col in data]
+        for key in cols_to_drop:
+            del data[key]
+        return data
+
+    def load_data_from_dialog(self, routine):
+        """
+        Load routine data from dialog window. Checks to make sure the data in the selected routine to load
+        matches VOCS from the environment + VOCS tab. If they match, update table with data.
+
+        Arguments:
+            routine (Xopt Routine) : A routine selected from the load data dialog
+
+        """
+        data = routine.data
+        vocs = self.parent._compose_vocs()[0]
+
+        # Create copy of data without metadata columns
+        filtered_data = self.filter_metadata(data)
+        # Raise error if loaded data keys do not match selected vocs
+        if not self.info:
+            data = filtered_data
+
+        if set(list(filtered_data.keys())) != set(
+            vocs.variable_names + vocs.output_names
+        ):
+            dialog = QMessageBox(
+                text=str(
+                    "Data must match selected Variables, Objectives\n\n"
+                    + "Please check the following:\n"
+                    + f"{list(set(list(data.keys())) ^ set(vocs.variable_names + vocs.output_names))}"
+                ),
+                parent=self,
+            )
+            dialog.setIcon(QMessageBox.Warning)
+            dialog.setStandardButtons(QMessageBox.Ok | QMessageBox.Cancel)
+            result = dialog.exec_()
+            if result == QMessageBox.Cancel:
+                return
+        else:
+            # All keys match, add selected routine data to table
+            combined_data = pd.concat([self.table_data, data], ignore_index=True)
+            self.update_table(
+                self.data_table, combined_data, routine.vocs, info=self.info
+            )
+
+    def load_data(self, routine):
+        """
+        Load data from routine and update table
+
+        Arguments:
+            routine (Xopt Routine):
+        """
+        self.set_routine(routine)
+        data = routine.data
+
+        self.update_table(
+            self.data_table,
+            data,
+            routine.vocs,
+            info=self.info,
+        )
+
+    def reset_data_table(self):
+        """Reset table and data"""
+        self.data_table.clear()
+        self.data_table.setRowCount(0)
+        self.data_table.setColumnCount(0)
+        self.table_data = pd.DataFrame()

--- a/src/badger/gui/acr/components/data_panel.py
+++ b/src/badger/gui/acr/components/data_panel.py
@@ -294,9 +294,7 @@ class BadgerDataPanel(QWidget):
         else:
             # All keys match, add selected routine data to table
             combined_data = pd.concat([self.table_data, data], ignore_index=True)
-            self.update_table(
-                self.data_table, combined_data, routine.vocs
-            )
+            self.update_table(self.data_table, combined_data, routine.vocs)
 
     def load_data(self, routine):
         """

--- a/src/badger/gui/acr/components/data_panel.py
+++ b/src/badger/gui/acr/components/data_panel.py
@@ -159,7 +159,15 @@ class BadgerDataPanel(QWidget):
 
     @property
     def use_data(self) -> bool:
-        return self.run_data_checkbox.isChecked()
+        """
+        True if run_data_checkbox is checked, and there is data to load.
+        Otherwise False.
+        """
+        if self.has_data and self.run_data_checkbox.isChecked():
+            return True
+        else:
+            self.run_data_checkbox.setChecked(False)
+            return False
 
     @property
     def init_points(self) -> bool:

--- a/src/badger/gui/acr/components/routine_page.py
+++ b/src/badger/gui/acr/components/routine_page.py
@@ -1695,10 +1695,6 @@ class BadgerRoutinePage(QWidget):
         if not vocs.objectives:
             raise BadgerRoutineError("no objectives selected")
 
-        # Make sure loaded data matches
-        if self.data_panel.use_data:
-            self.validate_loaded_data_keys(vocs)
-
         # Initial points
         init_points_df = pd.DataFrame.from_dict(
             get_table_content_as_dict(self.env_box.init_table)

--- a/src/badger/gui/acr/components/routine_page.py
+++ b/src/badger/gui/acr/components/routine_page.py
@@ -23,6 +23,7 @@ from xopt.utils import get_local_region
 from pydantic import ValidationError
 
 from badger.gui.acr.components.generator_cbox import BadgerAlgoBox
+from badger.gui.acr.components.data_panel import BadgerDataPanel
 from badger.gui.default.components.data_table import (
     get_table_content_as_dict,
     set_init_data_table,
@@ -253,6 +254,10 @@ class BadgerRoutinePage(QWidget):
         # Algo box
         self.generator_box = BadgerAlgoBox(None, self.generators)
         tabs.addTab(self.generator_box, "Algorithm")
+
+        # Data panel
+        self.data_panel = BadgerDataPanel(self)
+        tabs.addTab(self.data_panel, "Data")
 
         tabs.setCurrentIndex(1)  # Show the env box by default
 
@@ -1771,7 +1776,8 @@ class BadgerRoutinePage(QWidget):
                     )
                 else:
                     print(f"Caught warning: {warning.message}")
-
+            
+            self.data_panel.set_routine(routine)
             return routine
 
     def review(self):

--- a/src/badger/gui/acr/components/routine_page.py
+++ b/src/badger/gui/acr/components/routine_page.py
@@ -1695,6 +1695,10 @@ class BadgerRoutinePage(QWidget):
         if not vocs.objectives:
             raise BadgerRoutineError("no objectives selected")
 
+        # Make sure loaded data matches
+        if self.data_panel.use_data:
+            self.validate_loaded_data_keys(vocs)
+
         # Initial points
         init_points_df = pd.DataFrame.from_dict(
             get_table_content_as_dict(self.env_box.init_table)
@@ -1779,6 +1783,43 @@ class BadgerRoutinePage(QWidget):
 
             self.data_panel.set_routine(routine)
             return routine
+
+    def validate_loaded_data_keys(self, vocs):
+        """
+        Makes sure that the keys of data to be loaded from data_panel match the
+        variable and objective names in vocs. If they do not, raises an error.
+        If the set of data keys from self.data_panel matches provided VOCS variables
+        and objectives, opens a dialog to inform user that data has been added.
+
+        Args:
+            vocs: VOCS
+        """
+        data_keys = self.data_panel.get_data_as_dict().keys()
+
+        # Raise error if loaded data keys do not match selected vocs
+        if set(list(data_keys)) != set(vocs.variable_names + vocs.output_names):
+            raise BadgerRoutineError(
+                "The following keys loaded into generator data do not match selected VOCS:\n"
+                + f"{set(list(data_keys)) ^ set(vocs.variable_names + vocs.output_names)}"
+            )
+
+        # Notify user that data has been added to the routine
+        dialog = QMessageBox(
+            text=str(
+                "Data loaded into routine for the following objectives, variables:\n\n"
+                + f"{list(data_keys)}\n\n"
+                + "Click OK to continue!"
+            ),
+            parent=self,
+        )
+        dialog.setIcon(QMessageBox.Information)
+        dialog.setWindowTitle("Data added to routine")
+        dialog.setStandardButtons(QMessageBox.Ok | QMessageBox.Cancel)
+        result = dialog.exec_()
+
+        if result == QMessageBox.Cancel:
+            # There might be a more graceful way to do this?
+            raise BadgerRoutineError("Routine initialization cancelled by user.")
 
     def review(self):
         try:

--- a/src/badger/gui/acr/components/routine_page.py
+++ b/src/badger/gui/acr/components/routine_page.py
@@ -1776,7 +1776,7 @@ class BadgerRoutinePage(QWidget):
                     )
                 else:
                     print(f"Caught warning: {warning.message}")
-            
+
             self.data_panel.set_routine(routine)
             return routine
 

--- a/src/badger/gui/acr/components/routine_page.py
+++ b/src/badger/gui/acr/components/routine_page.py
@@ -1818,7 +1818,6 @@ class BadgerRoutinePage(QWidget):
         result = dialog.exec_()
 
         if result == QMessageBox.Cancel:
-            # There might be a more graceful way to do this?
             raise BadgerRoutineError("Routine initialization cancelled by user.")
 
     def review(self):

--- a/src/badger/gui/acr/components/routine_page.py
+++ b/src/badger/gui/acr/components/routine_page.py
@@ -61,6 +61,7 @@ from badger.utils import (
     strtobool,
     get_badger_version,
     get_xopt_version,
+    ts_float_to_str,
 )
 
 LABEL_WIDTH = 96
@@ -1738,6 +1739,7 @@ class BadgerRoutinePage(QWidget):
                 # Metadata
                 badger_version=get_badger_version(),
                 xopt_version=get_xopt_version(),
+                creation_ts=ts_float_to_str(datetime.now().timestamp(), "lcls-fname"),
                 # Xopt part
                 vocs=vocs,
                 generator=generator,

--- a/src/badger/gui/acr/pages/home_page.py
+++ b/src/badger/gui/acr/pages/home_page.py
@@ -376,12 +376,12 @@ class BadgerHomePage(QWidget):
 
     def start_run(self, use_termination_condition: bool = False):
         """
-        Prepares and starts optimization run with provided options. 
+        Prepares and starts optimization run with provided options.
         - Termination Condition is provided when called via BadgerTerminationConditionDialog
         - Data Options are collected from BadgerDataPanel
 
         Args:
-            use_termination_condition (bool): Is set as True if called from BadgerTerminationConditionDialog. 
+            use_termination_condition (bool): Is set as True if called from BadgerTerminationConditionDialog.
 
         """
 

--- a/src/badger/gui/acr/pages/home_page.py
+++ b/src/badger/gui/acr/pages/home_page.py
@@ -418,7 +418,6 @@ class BadgerHomePage(QWidget):
         )
 
     def start_run_until(self):
-        self.prepare_run()
         dlg = BadgerTerminationConditionDialog(
             self,
             self.start_run,

--- a/src/badger/gui/acr/pages/home_page.py
+++ b/src/badger/gui/acr/pages/home_page.py
@@ -361,6 +361,7 @@ class BadgerHomePage(QWidget):
 
         # Add data to routine before saving tmp file
         if data is not None:
+            self.routine_editor.routine_page.validate_loaded_data_keys(routine.vocs)
             routine.data = data
 
         self.current_routine = routine

--- a/src/badger/gui/default/components/routine_runner.py
+++ b/src/badger/gui/default/components/routine_runner.py
@@ -89,7 +89,7 @@ class BadgerRoutineSubprocess:
         """
         self.termination_condition = termination_condition
 
-    def run(self) -> None:
+    def run(self, data_options: dict) -> None:
         """
         This method starts up the routine.
         The method grabs a subprocess from self.process_manager queue.
@@ -110,7 +110,9 @@ class BadgerRoutineSubprocess:
         except TypeError:
             pass
 
-        self.routine.data = None  # reset data
+        if not data_options["run_data"]:
+            self.routine.data = None  # reset data
+
         # Recalculate the bounds and initial points if asked
         if (
             self.config_singleton.read_value("AUTO_REFRESH")
@@ -157,6 +159,7 @@ class BadgerRoutineSubprocess:
                 "termination_condition": self.termination_condition,
                 "start_time": self.start_time,
                 "testing": self.testing,
+                "data_options": data_options,
             }
 
             self.data_and_error_queue.put(arg_dict)
@@ -165,7 +168,9 @@ class BadgerRoutineSubprocess:
             self.setup_timer()
             # self.signals.finished.emit(self.routine.states)
 
-            self.routine.data = None  # reset data
+            if not data_options["run_data"]:
+                self.routine.data = None  # reset data
+
             # Recalculate the bounds and initial points if asked
             if (
                 self.config_singleton.read_value("AUTO_REFRESH")

--- a/src/badger/gui/default/components/run_monitor.py
+++ b/src/badger/gui/default/components/run_monitor.py
@@ -447,16 +447,17 @@ class BadgerOptMonitor(QWidget):
             self.sig_stop.disconnect()
             self.routine_runner = None
 
-    def start(self, use_termination_condition=False):
+    def start(self, data_options: dict, use_termination_condition: bool = False):
         self.sig_new_run.emit()
         self.sig_status.emit(f"Running routine {self.routine.name}...")
-        self.routine.data = None  # reset data if any
+        if data_options["run_data"] is False:
+            self.routine.data = None  # reset data if any
         self.init_plots(self.routine)
         self.init_routine_runner()
         if use_termination_condition:
             self.routine_runner.set_termination_condition(self.termination_condition)
         self.running = True  # if a routine runner is working
-        self.routine_runner.run()
+        self.routine_runner.run(data_options=data_options)
         self.sig_run_started.emit()
         self.sig_lock.emit(True)
 

--- a/src/badger/gui/default/components/run_monitor.py
+++ b/src/badger/gui/default/components/run_monitor.py
@@ -30,9 +30,6 @@ from badger.logbook import BADGER_LOGBOOK_ROOT, send_to_logbook
 from badger.routine import Routine
 from badger.tests.utils import get_current_vars
 from badger.gui.default.windows.message_dialog import BadgerScrollableMessageBox
-from badger.gui.default.windows.terminition_condition_dialog import (
-    BadgerTerminationConditionDialog,
-)
 
 from badger.gui.default.components.extensions_palette import ExtensionsPalette
 from badger.gui.default.components.routine_runner import BadgerRoutineSubprocess
@@ -946,19 +943,6 @@ class BadgerOptMonitor(QWidget):
     def stop(self):
         self.sig_stop.emit()
         self.sig_stop_run.emit()
-
-    def start_until(self):
-        dlg = BadgerTerminationConditionDialog(
-            self,
-            self.start,
-            self.save_termination_condition,
-            self.termination_condition,
-        )
-        self.tc_dialog = dlg
-        try:
-            dlg.exec()
-        finally:
-            self.tc_dialog = None
 
     def register_post_run_action(self, action):
         self.post_run_actions.append(action)

--- a/src/badger/gui/default/windows/load_data_from_run_dialog.py
+++ b/src/badger/gui/default/windows/load_data_from_run_dialog.py
@@ -1,0 +1,301 @@
+from PyQt5.QtWidgets import (
+    QDialog,
+    QWidget,
+    QHBoxLayout,
+    QPushButton,
+    QVBoxLayout,
+    QLabel,
+    QTableWidget,
+    QFileDialog,
+)
+import pyqtgraph as pg
+from pyqtgraph.Qt import QtGui, QtCore
+from typing import List
+import numpy as np
+import pandas as pd
+from badger.archive import (
+    get_base_run_filename,
+    get_runs,
+    load_run,
+)
+from badger.gui.acr.components.history_navigator import HistoryNavigator
+from badger.settings import init_settings
+from badger.errors import BadgerRoutineError
+
+stylesheet_run = """
+QPushButton:hover:pressed
+{
+    background-color: #92D38C;
+}
+QPushButton:hover
+{
+    background-color: #6EC566;
+}
+QPushButton
+{
+    background-color: #4AB640;
+    color: #000000;
+}
+"""
+
+
+class BadgerLoadDataFromRunDialog(QDialog):
+    """
+    Dialog for loading generator data in Badger. Provides a UI for selecting a run,
+    previewing its data, and loading the data into the application.
+    """
+
+    def __init__(self, parent, data_table=None, on_set=None):
+        """
+        Initialize the dialog.
+
+        Args:
+            parent (QWidget): The parent widget.
+            data_table (QTableWidget, optional): The data table to update with loaded run data.
+
+        Attributes:
+            data_table (QTableWidget): The data table to update with loaded run data.
+            selected_routine (Optional[Routine]): The currently selected routine.
+        """
+        super().__init__(parent)
+
+        self.data_table = data_table
+        self.selected_routine = None
+        self.on_set = on_set  # function from parent to call when loading data
+
+        self.init_ui()
+        self.config_logic()
+
+    def init_ui(self):
+        """
+        Initialize the user interface.
+        """
+        config_singleton = init_settings()
+        self.BADGER_ARCHIVE_ROOT = config_singleton.read_value("BADGER_ARCHIVE_ROOT")
+
+        self.setWindowTitle("Load Data from Run")
+        self.setMinimumWidth(400)
+
+        vbox = QVBoxLayout(self)
+
+        # Header and labels
+        header = QWidget()
+        header_hbox = QHBoxLayout(header)
+        header_hbox.setContentsMargins(0, 0, 0, 0)
+
+        label = QLabel("Select run to load data into generator:")
+        label.setFixedWidth(360)
+        plot_label = QLabel("Data Preview:")
+        plot_label.setFixedWidth(550)
+        var_table_label = QLabel("Variables:")
+
+        header_hbox.addWidget(label)
+        header_hbox.addWidget(plot_label)
+        header_hbox.addWidget(var_table_label)
+
+        content_widget = QWidget()
+        hbox_content = QHBoxLayout(content_widget)
+        hbox_content.setContentsMargins(0, 0, 0, 0)
+
+        # History run browser
+        self.history_browser = HistoryNavigator()
+        self.history_browser.setFixedWidth(360)
+        runs = get_runs()
+        self.history_browser.updateItems(runs)
+        self.history_browser.tree_widget.itemSelectionChanged.connect(self.preview_run)
+        hbox_content.addWidget(self.history_browser)
+
+        # Data preview
+        self.data_preview = self.init_plots()
+        self.data_preview.setFixedWidth(550)
+        hbox_content.addWidget(self.data_preview)
+
+        # Button set
+        button_set = QWidget()
+        hbox_set = QHBoxLayout(button_set)
+        hbox_set.setContentsMargins(0, 0, 0, 0)
+        self.btn_from_file = QPushButton("Open File")
+        self.btn_cancel = QPushButton("Cancel")
+        self.btn_load = QPushButton("Load")
+        self.btn_from_file.setFixedSize(96, 24)
+        self.btn_cancel.setFixedSize(96, 24)
+        self.btn_load.setFixedSize(96, 24)
+        hbox_set.addWidget(self.btn_from_file)
+        hbox_set.addStretch()
+        hbox_set.addWidget(self.btn_cancel)
+        hbox_set.addWidget(self.btn_load)
+
+        vbox.addWidget(header)
+        vbox.addWidget(content_widget)
+        vbox.addWidget(button_set)
+
+    def preview_run(self, routine=None):
+        """
+        Add data to plot to preview the selected run.
+        """
+        # load data from selected run
+        if routine:
+            self.selected_routine = routine
+        else:
+            self.selected_routine = routine = self.load_data(
+                get_base_run_filename(self.history_browser.currentText())
+            )
+
+        if routine is None:
+            return
+
+        # Configure plots
+        curves_objective = self._configure_plot(
+            self.plot_obj,
+            routine.vocs.output_names,
+        )
+
+        curves_variable = self._configure_plot(
+            self.plot_var,
+            routine.vocs.variable_names,
+        )
+
+        self._set_plot_data(
+            routine.vocs.output_names, curves_objective, routine.generator.data
+        )
+        self._set_plot_data(
+            routine.vocs.variable_names, curves_variable, routine.generator.data
+        )
+
+    def config_logic(self):
+        self.btn_cancel.clicked.connect(self.cancel_changes)
+        self.btn_load.clicked.connect(self.select_run)
+        self.btn_from_file.clicked.connect(self.load_from_file)
+
+    def select_run(self):
+        """
+        Update the data table with variable and objective data from the selected routine
+        """
+        self.on_set(self.selected_routine)
+        self.close()
+
+    def load_from_file(self):
+        options = QFileDialog.Options()
+        options |= QFileDialog.ReadOnly
+        file_path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Load Data from File",
+            "~",
+            "YAML Files (*.yaml *.yml);;All Files (*)",
+            options=options,
+        )
+
+        if not file_path:
+            return
+
+        try:
+            routine = load_run(file_path)
+            self.preview_run(routine)
+        except Exception as e:
+            raise BadgerRoutineError(f"{e}")
+
+    def load_data(self, run_filename: str):
+        """
+        Load data from the selected run.
+
+        Returns:
+            Optional[Routine]: The loaded routine or None if loading fails.
+        """
+        if not run_filename:
+            return
+        try:
+            routine = load_run(run_filename)
+            return routine
+        except IndexError:
+            return
+        except Exception:  # failed to load the run
+            return
+
+    def init_plots(self):
+        """
+        Initialize the plots for data preview. These are static plots styled to
+        match the plots on the main GUI from BadgerOptMonitor
+        Note: it might be helpful to have some sort of BadgerPlot class
+            to be used within the BadgerOptMonitor, which could
+            then be reused here!
+
+        Returns:
+            pg.GraphicsLayoutWidget: The widget containing the plots.
+        """
+        self.colors = ["c", "g", "m", "y", "b", "r", "w"]
+
+        plot_layout = pg.GraphicsLayoutWidget()
+
+        # create objectives plot
+        self.plot_obj = plot_layout.addPlot(
+            row=0, col=0, title="Evaluation History (Y)"
+        )
+        self.plot_obj.setLabel("left", "objectives")
+        self.plot_obj.setLabel("bottom", "iterations")
+        self.plot_obj.showGrid(x=True, y=True)
+        leg_obj = self.plot_obj.addLegend()
+        leg_obj.setBrush((50, 50, 100, 200))
+
+        self.plot_var = plot_layout.addPlot(
+            row=1, col=0, title="Relative Variable History (Y)"
+        )
+        self.plot_var.setLabel("left", "variables")
+        self.plot_var.setLabel("bottom", "iterations")
+        self.plot_var.showGrid(x=True, y=True)
+        leg_obj = self.plot_var.addLegend()
+        leg_obj.setBrush((50, 50, 100, 200))
+
+        return plot_layout
+
+    def _configure_plot(self, plot_object, names):
+        """
+        Configure the plot with the given data names.
+        Adapted from BadgerOptMonitor._configure_plot
+
+        Args:
+            plot_object (pg.PlotItem): The plot object to configure.
+            names (List[str]): The names of the data series.
+
+        Returns:
+            dict: A dictionary mapping data names to plot curves.
+        """
+        plot_object.clear()
+        curves = {}
+        for i, name in enumerate(names):
+            color = self.colors[i % len(self.colors)]
+
+            # add a dot symbol to the plot to handle cases were there are many nans
+            dot_symbol = QtGui.QPainterPath()
+            size = 0.075  # size of the dot symbol
+            dot_symbol.addEllipse(QtCore.QRectF(-size / 2, -size / 2, size, size))
+
+            pen = pg.mkPen(color, width=3)
+            _curve = plot_object.plot(
+                pen=pen,
+                symbol=dot_symbol,
+                symbolPen=pen,
+                name=name,
+                symbolBrush=pen.color(),
+            )
+            curves[name] = _curve
+
+        return curves
+
+    def _set_plot_data(
+        self, names: List[str], curves: dict, data: pd.DataFrame, ts=None
+    ):
+        """
+        Set data for the plot curves.
+        Adapted from BadgerOptMonitor.set_data
+        """
+        for name in names:
+            if ts is not None:
+                curves[name].setData(ts, data[name].to_numpy(dtype=np.double))
+            else:
+                curves[name].setData(data[name].to_numpy(dtype=np.double))
+
+    def cancel_changes(self):
+        self.close()
+
+    def closeEvent(self, event):
+        event.accept()

--- a/src/badger/gui/default/windows/load_data_from_run_dialog.py
+++ b/src/badger/gui/default/windows/load_data_from_run_dialog.py
@@ -5,7 +5,6 @@ from PyQt5.QtWidgets import (
     QPushButton,
     QVBoxLayout,
     QLabel,
-    QTableWidget,
     QFileDialog,
 )
 import pyqtgraph as pg

--- a/src/badger/routine.py
+++ b/src/badger/routine.py
@@ -23,6 +23,7 @@ from badger.environment import BaseEnvironment, instantiate_env
 
 class Routine(Xopt):
     id: Optional[str] = Field(None)
+    creation_ts: Optional[str] = Field(None)  # Timestamp of routine creation
     name: str
     description: Optional[str] = Field(None)
     environment: SerializeAsAny[BaseEnvironment]


### PR DESCRIPTION
This PR adds the ability to continue a previous routine, and load data from historical badger runs into a new routine. 
Here is a summary of the changes:

UI changes:
- Added a new Data tab to the BadgerRoutinePage
  - The Data tab includes a table showing data in the selected routine, which mirrors functionality of current run data table
  - "Add Data" button to add data from previous Badger runs. This launches a new dialog window
  - "Clear Table" button clears the table. This does not affect the run monitor or data in selected routine
  - Checkbox options to "Load displayed data into routine" and "Skip initial point sampling"
-  New dialog window for selecting data from previous Badger runs

Functionality changes:
- Added a "creation_ts" timestamp, and modified routine file naming so that files are named based on their creation timestamp instead of first data point
- Modified "start_run" function in BadgerHomePage to create a "data_options" dictionary, with flags to load data and skip initial point sampling based on Data tab checkbox states. This gets passed to the run monitor and subsequently to the routine sub-process.
- Moved "start_run_until" (termination condition) from run_monitor to home_page
