### PR TITLE
TST: fix test related to plot axis labeling started to add scale value, ex: 'iterations (x0.001)' instead of expected 'iterations'

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 
 <div align="center">
 
-| Documentation | Package | Downloads | Version | Platforms |
-| --- | --- | --- | --- | --- |
-| [![Documentation](https://img.shields.io/badge/Badger-documentation-blue.svg)](https://xopt-org.github.io/Badger/) | [![Conda Recipe](https://img.shields.io/badge/recipe-badger-opt.svg)](https://anaconda.org/conda-forge/badger-opt) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/badger-opt.svg)](https://anaconda.org/conda-forge/badger-opt) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/badger-opt.svg)](https://anaconda.org/conda-forge/badger-opt) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/badger-opt.svg)](https://anaconda.org/conda-forge/badger-opt) |
+| Documentation | Package | Downloads | Version | Platforms | Tests |
+| --- | --- | --- | --- | --- | --- |
+| [![Documentation](https://img.shields.io/badge/Badger-documentation-blue.svg)](https://xopt-org.github.io/Badger/) | [![Conda Recipe](https://img.shields.io/badge/recipe-badger-opt.svg)](https://anaconda.org/conda-forge/badger-opt) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/badger-opt.svg)](https://anaconda.org/conda-forge/badger-opt) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/badger-opt.svg)](https://anaconda.org/conda-forge/badger-opt) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/badger-opt.svg)](https://anaconda.org/conda-forge/badger-opt) | [![Tests](https://github.com/xopt-org/Badger/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/xopt-org/Badger/actions/workflows/tests.yml?query=branch%3Amain)
 
 </div>
 

--- a/src/badger/tests/test_run_monitor.py
+++ b/src/badger/tests/test_run_monitor.py
@@ -185,10 +185,10 @@ class TestRunMonitor:
 
         # Test label setting
         plot_var_axis = monitor.plot_var.getAxis("bottom")
-        assert plot_var_axis.label.toPlainText().strip() == "iterations"
+        assert plot_var_axis.label.toPlainText().startswith("iterations")
 
         plot_obj_axis = monitor.plot_obj.getAxis("bottom")
-        assert plot_obj_axis.label.toPlainText().strip() == "iterations"
+        assert plot_obj_axis.label.toPlainText().startswith("iterations")
 
         if monitor.vocs.constraint_names:
             plot_con_axis = monitor.plot_con.getAxis("bottom")
@@ -204,10 +204,10 @@ class TestRunMonitor:
 
         # Test label setting
         plot_var_axis_time = monitor.plot_var.getAxis("bottom")
-        assert plot_var_axis_time.label.toPlainText().strip() == "time (s)"
+        assert plot_var_axis_time.label.toPlainText().startswith("time (s)")
 
         plot_obj_axis_time = monitor.plot_obj.getAxis("bottom")
-        assert plot_obj_axis_time.label.toPlainText().strip() == "time (s)"
+        assert plot_obj_axis_time.label.toPlainText().startswith("time (s)")
 
         if monitor.vocs.constraint_names:
             plot_con_axis_time = monitor.plot_con.getAxis("bottom")


### PR DESCRIPTION
seems like new release of pyqtgraph (0.14.0) broke the test, in specific: https://github.com/pyqtgraph/pyqtgraph/pull/3136.
related to added 'siPrefixEnableRanges' arg for graph axis labels, which results in the added scaling text "(x0.001)".

lets update the test itself to pass for both axis label text, so tests can still pass with older pyqtgraph versions.

also add display of testing result (the last run on main) to github page (so easier to tell when tests break).