### PR TITLE
Add 'expand to fullscreen' button to top-bar of some windows where it's nice to have

### DIFF
--- a/src/badger/gui/windows/expandable_message_box.py
+++ b/src/badger/gui/windows/expandable_message_box.py
@@ -8,6 +8,7 @@ from PyQt5.QtWidgets import (
     QTextEdit,
 )
 from PyQt5.QtGui import QTextOption, QFont, QFontDatabase
+from PyQt5.QtCore import Qt
 
 
 class ExpandableMessageBox(QDialog):
@@ -15,6 +16,7 @@ class ExpandableMessageBox(QDialog):
         self, icon=None, title="Message", text="", detailedText="", parent=None
     ):
         super().__init__(parent)
+        self.setWindowFlags(self.windowFlags() | Qt.WindowMaximizeButtonHint)
 
         # Main layout
         mainLayout = QVBoxLayout(self)

--- a/src/badger/gui/windows/load_data_from_run_dialog.py
+++ b/src/badger/gui/windows/load_data_from_run_dialog.py
@@ -7,6 +7,7 @@ from PyQt5.QtWidgets import (
     QLabel,
     QFileDialog,
 )
+from PyQt5.QtCore import Qt
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtGui, QtCore
 from typing import List, Callable
@@ -64,6 +65,7 @@ class BadgerLoadDataFromRunDialog(QDialog):
             selected_routine (Optional[Routine]): The currently selected routine.
         """
         super().__init__(parent)
+        self.setWindowFlags(self.windowFlags() | Qt.WindowMaximizeButtonHint)
 
         self.data_table = data_table
         self.selected_routine = None

--- a/src/badger/gui/windows/message_dialog.py
+++ b/src/badger/gui/windows/message_dialog.py
@@ -9,6 +9,7 @@ from PyQt5.QtWidgets import (
     QTextEdit,
 )
 from PyQt5.QtGui import QTextOption, QFont, QFontDatabase
+from PyQt5.QtCore import Qt
 # from ..components.eliding_label import ElidingLabel
 
 
@@ -17,6 +18,7 @@ class BadgerScrollableMessageBox(QDialog):
         self, icon=None, title="Message", text="", detailedText="", parent=None
     ):
         super().__init__(parent)
+        self.setWindowFlags(self.windowFlags() | Qt.WindowMaximizeButtonHint)
 
         # Main layout
         mainLayout = QVBoxLayout(self)

--- a/src/badger/gui/windows/settings_dialog.py
+++ b/src/badger/gui/windows/settings_dialog.py
@@ -16,6 +16,7 @@ from PyQt5.QtWidgets import (
     QDialogButtonBox,
     QApplication,
 )
+from PyQt5.QtCore import Qt
 from qdarkstyle import load_stylesheet, DarkPalette, LightPalette
 from badger.settings import init_settings
 from badger.log import get_logging_manager
@@ -35,6 +36,7 @@ class BadgerSettingsDialog(QDialog):
     def __init__(self, parent):
         logger.info("Initializing BadgerSettingsDialog.")
         super().__init__(parent)
+        self.setWindowFlags(self.windowFlags() | Qt.WindowMaximizeButtonHint)
 
         self.config_singleton = init_settings()
 


### PR DESCRIPTION
especially error window, so don't have to drag window to full-screen anymore to see full error output.

i've personally been wanting these buttons added.