### PR TITLE
Add setting for pytorch tensor-sharing strategy (fix for 'OSError: [Errno 24] Too many open files')

### DIFF
--- a/src/badger/actions/__init__.py
+++ b/src/badger/actions/__init__.py
@@ -1,6 +1,8 @@
+import os
 from importlib import metadata
 from badger.actions.doctor import check_n_config_paths
 from badger.utils import yprint
+from badger.settings import init_settings, get_user_config_folder
 
 
 def show_info(args):
@@ -20,7 +22,8 @@ def show_info(args):
     if not check_n_config_paths():
         return
 
-    from badger.settings import init_settings
+    config_path = get_user_config_folder()
+    configfile_path = os.path.join(config_path, "config.yaml")
 
     config_singleton = init_settings()
     BADGER_PLUGIN_ROOT = config_singleton.read_value("BADGER_PLUGIN_ROOT")
@@ -29,17 +32,21 @@ def show_info(args):
     BADGER_ARCHIVE_ROOT = config_singleton.read_value("BADGER_ARCHIVE_ROOT")
     BADGER_LOG_DIRECTORY = config_singleton.read_value("BADGER_LOG_DIRECTORY")
     BADGER_LOG_LEVEL = config_singleton.read_value("BADGER_LOG_LEVEL")
-
+    BADGER_TENSOR_STRATEGY = config_singleton.read_value(
+        "BADGER_PYTORCH_TENSOR_SHARING_STRATEGY"
+    )
     info = {
         "name": "Badger the optimizer",
         "version": metadata.version("badger-opt"),
         "xopt version": metadata.version("xopt"),
+        "config-file path": configfile_path,
         "plugin root": BADGER_PLUGIN_ROOT,
         "template root": BADGER_TEMPLATE_ROOT,
         "logbook root": BADGER_LOGBOOK_ROOT,
         "archive root": BADGER_ARCHIVE_ROOT,
         "logging directory": BADGER_LOG_DIRECTORY,
         "logging level": BADGER_LOG_LEVEL,
+        "pytorch tensor sharing strategy": BADGER_TENSOR_STRATEGY,
         # 'plugin installation url': read_value('BADGER_PLUGINS_URL')
     }
 

--- a/src/badger/core_subprocess.py
+++ b/src/badger/core_subprocess.py
@@ -7,7 +7,10 @@ from pandas import DataFrame
 import multiprocessing as mp
 import os
 
-from badger.settings import init_settings
+from badger.settings import (
+    init_settings,
+    apply_pytorch_multiprocess_tensor_sharing_setting,
+)
 from badger.errors import BadgerRunTerminated, BadgerEnvObsError
 from badger.logger import _get_default_logger
 from badger.logger.event import Events
@@ -108,7 +111,11 @@ def run_routine_subprocess(
 
     # Initialize the settings singleton with the provided config path
     logger.info(f"Initializing settings with config path: {config_path}")
-    init_settings(config_path)
+    config_values = init_settings(config_path)
+    # Applying this setting is quick, so let's just set b4 each run incase later we want to expose it
+    # in the settings window (meaning user can change setting without reloading Badger).
+    apply_pytorch_multiprocess_tensor_sharing_setting(config_values)
+
     # Now load the archive would use the correct config
     from badger.archive import load_run, archive_run
 

--- a/src/badger/settings.py
+++ b/src/badger/settings.py
@@ -59,6 +59,8 @@ class BadgerConfig(BaseModel):
         Setting for the GUI theme.
     BADGER_ENABLE_ADVANCED : Setting
         Setting to enable advanced features in the GUI.
+    BADGER_PYTORCH_TENSOR_SHARING_STRATEGY: Setting
+        Setting for strategy pytorch will use when passing tensors to subprocesses.
     """
 
     BADGER_PLUGIN_ROOT: Setting = Setting(
@@ -113,6 +115,12 @@ class BadgerConfig(BaseModel):
         display_name="enable advanced features",
         description="Enable advanced features on the GUI",
         value=False,
+        is_path=False,
+    )
+    BADGER_PYTORCH_TENSOR_SHARING_STRATEGY: Setting = Setting(
+        display_name="torch tensor sharing strategy",
+        description="Setting for which strategy pytorch will use when passing tensors to subprocesses. Valid options are 'file_system' (default) or 'file_descriptor'",
+        value="file_system",
         is_path=False,
     )
     AUTO_REFRESH: Setting = Setting(
@@ -425,6 +433,49 @@ def init_settings(config_arg: str = None) -> ConfigSingleton:
 
     config_singleton = ConfigSingleton(file_path, user_flag)
     return config_singleton
+
+
+def apply_pytorch_multiprocess_tensor_sharing_setting(
+    config_singleton: ConfigSingleton,
+) -> None:
+    # The pytorch sharing strategy 'file_descriptor' (which linux often defaults to) can hit os file descriptor limits.
+    # Hitting this limit causes error to occur: 'OSError: [Errno 24] Too many open files'.
+    # (File descriptor limit is set for each shell process and see it with 'ulimit -n')
+    # Switching to the 'file_system' strategy makes this error impossible to hit, since pytorch will instead use temporary files for
+    # passing tensors to subprocesses instead of file descriptors.
+    # We provide a way to configure this setting since there can be some downsides to using "file_system",
+    # these being a potential small performance hit, and needing to use up some temp location disk space (exact location is os dependant).
+    try:
+        strategy = config_singleton.read_value("BADGER_PYTORCH_TENSOR_SHARING_STRATEGY")
+    except KeyError:  # default to using temp files instead of the descriptors
+        strategy = "file_system"
+
+    strategy = str(strategy).strip().lower()
+    if strategy != "file_system" and strategy != "file_descriptor":
+        logger.exception(
+            f"Invalid pytorch multiprocess tensor-sharing strategy '{strategy}', please use either 'file_system' or 'file_descriptor'. "
+            "Defaulting to using strategy 'file_system'"
+        )
+        return
+
+    try:
+        import torch
+    except ImportError:
+        logger.warning(
+            "Pytorch not available to import, can't apply multiprocess tensor-sharing strategy '%s'",
+            strategy,
+        )
+        return
+
+    try:
+        torch.multiprocessing.set_sharing_strategy(strategy)
+    except Exception:
+        logger.exception(
+            "Can't set pytorch multiprocess tensor-sharing strategy to '%s'", strategy
+        )
+        return
+
+    logger.info("Set pytorch multiprocess tensor-sharing strategy to '%s'", strategy)
 
 
 def mock_settings():

--- a/src/badger/tests/test_cli_basic.py
+++ b/src/badger/tests/test_cli_basic.py
@@ -18,7 +18,7 @@ def test_cli_main():
 
     # Check output lines
     outlines = out.splitlines()
-    assert len(outlines) == 9
+    assert len(outlines) == 11
 
     # Check name
     assert outlines[0] == "name: Badger the optimizer"


### PR DESCRIPTION
Can be set to either 'file_system' (default) or 'file_descriptor'.

Context:
The pytorch sharing strategy 'file_descriptor' (which linux often defaults to) can hit os file descriptor limits. Hitting this limit causes error to occur: 'OSError: [Errno 24] Too many open files'. (File descriptor limit is set for each shell process and see it with 'ulimit -n')

Switching to the 'file_system' strategy makes this error impossible to hit, since pytorch will instead use temporary files for passing tensors to subprocesses instead of file descriptors.

We provide a way to configure this setting since there can be some downsides to using "file_system",
these being a potential small performance hit, and needing to use up some temp location disk space (exact location is os dependent).



To see the difference:
- open terminal and run `ulimit -Sn 100` to set the fd limit very low
- open badger once on this patch so config file gets new section BADGER_PYTORCH_TENSOR_SHARING_STRATEGY
- edit badger config-file's BADGER_PYTORCH_TENSOR_SHARING_STRATEGY to value `file_descriptor`
- open badger from this same terminal and run a routine
- it should hit error 'OSError: [Errno 24] Too many open files'.
- change config-file's BADGER_PYTORCH_TENSOR_SHARING_STRATEGY to value `file_system`
- reopen badger and run routine, it should not crash!

Also adds config-file's full-path to info shown when running just `badger`.