### PR TITLE
Bug fix: variable range not setting correct variable in table

### DIFF
--- a/src/badger/gui/components/var_table.py
+++ b/src/badger/gui/components/var_table.py
@@ -1,3 +1,4 @@
+from functools import partial
 from importlib import resources
 import traceback
 from typing import Any, cast
@@ -404,7 +405,7 @@ class VariableTable(QTableWidget):
             layout.setContentsMargins(2, 0, 0, 0)  # Remove extra margins
             self.setCellWidget(i, 4, button_container)
 
-            config_button.clicked.connect(lambda: self.handle_config_button(name))
+            config_button.clicked.connect(partial(self.handle_config_button, name))
 
             if self.bounds_locked:
                 sb_lower.setEnabled(False)


### PR DESCRIPTION
This fixes a bug in the current var_table code where all of the variable config_buttons get connected to updating the last item in the table. Changing the code to connect using `functools.partial `uses the value of `name` when the connection is created, while `lambda` uses the value of `name` when the function gets called (when the button is clicked), which is the last value in the loop