### PR TITLE
Add retry measurements dialog window

### DIFF
--- a/src/badger/core_subprocess.py
+++ b/src/badger/core_subprocess.py
@@ -3,6 +3,7 @@ import logging
 import time
 import traceback
 from typing import Any
+from queue import Empty
 from pandas import DataFrame
 import multiprocessing as mp
 import os
@@ -11,7 +12,14 @@ from badger.settings import (
     init_settings,
     apply_pytorch_multiprocess_tensor_sharing_setting,
 )
-from badger.errors import BadgerRunTerminated, BadgerEnvObsError
+from badger.errors import (
+    BadgerRunTerminated,
+    BadgerEnvObsError,
+    MEASUREMENT_ERROR_TYPE,
+    MEASUREMENT_ACTION_TYPE,
+    MEASUREMENT_ACTION_RETRY,
+    MEASUREMENT_ACTION_ABORT,
+)
 from badger.logger import _get_default_logger
 from badger.logger.event import Events
 from badger.routine import Routine
@@ -21,6 +29,52 @@ from xopt.vocs import select_best
 
 
 logger = logging.getLogger(__name__)
+
+
+def evaluate_measurement_with_retry(
+    routine: Routine,
+    point: Any,
+    queue: mp.Queue,
+    stop_process: mp.Event,
+    dialog_action_queue: mp.Queue,
+) -> DataFrame:
+    while True:
+        try:
+            return routine.evaluate_data(point)
+        except Exception as e:
+            error_title = f"{type(e).__name__}: {e}"
+            error_traceback = traceback.format_exc()
+            logger.error(f"Measurement failed: {error_title}\n{error_traceback}")
+            queue.put(
+                {
+                    "type": MEASUREMENT_ERROR_TYPE,
+                    "title": error_title,
+                    "traceback": error_traceback,
+                }
+            )
+
+            # Wait for response back from retry dialog
+            while True:
+                if stop_process.is_set():
+                    raise BadgerRunTerminated
+                try:
+                    msg = dialog_action_queue.get(
+                        timeout=0.1
+                    )  # short timeout here, so we can make checks for stop_process
+                except Empty:
+                    continue
+
+                if (
+                    isinstance(msg, dict)
+                    and msg.get("type") == MEASUREMENT_ACTION_TYPE
+                    and msg.get("action")
+                    in [MEASUREMENT_ACTION_RETRY, MEASUREMENT_ACTION_ABORT]
+                ):
+                    if msg["action"] == MEASUREMENT_ACTION_RETRY:
+                        break
+                    raise BadgerRunTerminated(
+                        f"Run terminated after measurement error: {error_title}"
+                    )
 
 
 def convert_to_solution(result: DataFrame, routine: Routine):
@@ -82,6 +136,7 @@ def run_routine_subprocess(
     wait_event: mp.Event,
     config_path: str = None,
     log_queue: mp.Queue = None,
+    dialog_action_queue: mp.Queue = None,
 ) -> None:
     """
     Run the provided routine object using Xopt. This method is run as a subproccess
@@ -96,7 +151,6 @@ def run_routine_subprocess(
     config_path: str
     log_queue: mp.Queue
     """
-
     # Setup logging for this subprocess
     if log_queue is not None:
         configure_process_logging(
@@ -217,7 +271,9 @@ def run_routine_subprocess(
             logger.info("Evaluating initial points...")
             for _, ele in initial_points.iterrows():
                 logger.debug(f"Evaluating initial point: {ele.to_dict()}")
-                result = routine.evaluate_data(ele.to_dict())
+                result = evaluate_measurement_with_retry(
+                    routine, ele.to_dict(), queue, stop_process, dialog_action_queue
+                )
                 solution = convert_to_solution(result, routine)
                 opt_logger.update(Events.OPTIMIZATION_STEP, solution)
                 if evaluate:
@@ -280,7 +336,9 @@ def run_routine_subprocess(
                 )
                 pause_process.wait()
 
-            result = routine.evaluate_data(candidates)
+            result = evaluate_measurement_with_retry(
+                routine, candidates, queue, stop_process, dialog_action_queue
+            )
             solution = convert_to_solution(result, routine)
             opt_logger.update(Events.OPTIMIZATION_STEP, solution)
 

--- a/src/badger/errors.py
+++ b/src/badger/errors.py
@@ -109,3 +109,11 @@ class BadgerRoutineError(Exception):
 class BadgerRunTerminated(Exception):
     def __init__(self, message="Optimization run has been terminated!"):
         super().__init__(message)
+
+
+# Constants for measurement-error retry option feature.
+# Used in communication between routine runner and subprocess.
+MEASUREMENT_ERROR_TYPE = "measurement_error"
+MEASUREMENT_ACTION_TYPE = "measurement_action"
+MEASUREMENT_ACTION_RETRY = "retry"
+MEASUREMENT_ACTION_ABORT = "abort"

--- a/src/badger/gui/components/create_process.py
+++ b/src/badger/gui/components/create_process.py
@@ -33,6 +33,7 @@ class CreateProcess(QObject):
         self.data_queue = Queue()
         self.evaluate_queue = Pipe()
         self.wait_event = Event()
+        self.dialog_action_queue = Queue()
         config_path = init_settings()._instance.config_path
 
         # Get the logging queue from the centralized manager
@@ -50,6 +51,7 @@ class CreateProcess(QObject):
                 self.wait_event,
                 config_path,
                 log_queue,
+                self.dialog_action_queue,
             ),
         )
         new_process.start()
@@ -61,6 +63,7 @@ class CreateProcess(QObject):
                 "data_queue": self.data_queue,
                 "evaluate_queue": self.evaluate_queue,
                 "wait_event": self.wait_event,
+                "dialog_action_queue": self.dialog_action_queue,
             }
         )
         self.finished.emit()

--- a/src/badger/gui/components/routine_runner.py
+++ b/src/badger/gui/components/routine_runner.py
@@ -4,14 +4,22 @@ import traceback
 
 import pandas as pd
 from PyQt5.QtCore import pyqtSignal, QObject, QTimer
+from PyQt5.QtWidgets import QDialog
 
-from badger.errors import BadgerRunTerminated
+from badger.errors import (
+    BadgerRunTerminated,
+    BadgerError,
+    MEASUREMENT_ERROR_TYPE,
+    MEASUREMENT_ACTION_TYPE,
+    MEASUREMENT_ACTION_RETRY,
+    MEASUREMENT_ACTION_ABORT,
+)
 from badger.tests.utils import get_current_vars
 from badger.routine import calculate_variable_bounds, calculate_initial_points
 from badger.settings import init_settings
 from badger.gui.components.process_manager import ProcessManager
+from badger.gui.windows.measurement_retry_dialog import BadgerMeasurementRetryDialog
 from badger.routine import Routine
-from badger.errors import BadgerError
 
 logger = logging.getLogger(__name__)
 
@@ -149,6 +157,7 @@ class BadgerRoutineSubprocess:
             self.data_and_error_queue = process_with_args["data_queue"]
             self.evaluate_queue = process_with_args["evaluate_queue"]
             self.wait_event = process_with_args["wait_event"]
+            self.dialog_action_queue = process_with_args["dialog_action_queue"]
 
             arg_dict = {
                 "routine_id": self.routine.id,
@@ -234,14 +243,34 @@ class BadgerRoutineSubprocess:
 
         if not self.data_and_error_queue.empty():
             try:
-                error_title, error_traceback = self.data_and_error_queue.get()
-                BadgerError(error_title, error_traceback)
+                msg = self.data_and_error_queue.get()
+                if isinstance(msg, dict) and msg.get("type") == MEASUREMENT_ERROR_TYPE:
+                    action = self.handle_measurement_error(msg)
+                    self.dialog_action_queue.put(
+                        {
+                            "type": MEASUREMENT_ACTION_TYPE,
+                            "action": action,
+                        }
+                    )
+                else:
+                    error_title, error_traceback = msg
+                    BadgerError(error_title, error_traceback)
             except ValueError:  # seems to only occur in tests
                 pass
 
         if not self.routine_process.is_alive():
             self.close()
             self.evaluate_queue[1].close()
+
+    def handle_measurement_error(self, msg: dict) -> str:
+        dialog = BadgerMeasurementRetryDialog(
+            text=msg.get("title", "Measurement failed."),
+            detailedText=msg.get("traceback", ""),
+        )
+        result = dialog.exec_()
+        if result == QDialog.Accepted:
+            return MEASUREMENT_ACTION_RETRY
+        return MEASUREMENT_ACTION_ABORT
 
     def after_evaluate(self, results: pd.DataFrame) -> None:
         logger.debug("Received evaluation results from subprocess.")

--- a/src/badger/gui/windows/measurement_retry_dialog.py
+++ b/src/badger/gui/windows/measurement_retry_dialog.py
@@ -2,9 +2,8 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QFont, QFontDatabase, QTextOption
 from PyQt5.QtWidgets import (
     QDialog,
-    QHBoxLayout,
     QLabel,
-    QPushButton,
+    QDialogButtonBox,
     QScrollArea,
     QTextEdit,
     QVBoxLayout,
@@ -34,21 +33,21 @@ class BadgerMeasurementRetryDialog(QDialog):
         scrollArea.setWidgetResizable(True)
         self.detailedTextWidget = QTextEdit(detailedText)
         self.detailedTextWidget.setReadOnly(True)
-        self.detailedTextWidget.setWordWrapMode(QTextOption.NoWrap)
+        self.detailedTextWidget.setWordWrapMode(QTextOption.WrapAnywhere)
         monoFont = QFontDatabase.systemFont(QFontDatabase.FixedFont)
         monoFont.setPointSize(12)
         self.detailedTextWidget.setFont(monoFont)
         scrollArea.setWidget(self.detailedTextWidget)
         mainLayout.addWidget(scrollArea)
 
-        buttonBox = QHBoxLayout()
-        self.retryButton = QPushButton("Retry Measurement")
-        self.stopButton = QPushButton("Stop Run")
-        self.retryButton.clicked.connect(self.accept)
-        self.stopButton.clicked.connect(self.reject)
-        buttonBox.addWidget(self.retryButton)
-        buttonBox.addWidget(self.stopButton)
-        mainLayout.addLayout(buttonBox)
+        self.buttonBox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        self.retryButton = self.buttonBox.button(QDialogButtonBox.Ok)
+        self.retryButton.setText("Retry Measurement")
+        self.stopButton = self.buttonBox.button(QDialogButtonBox.Cancel)
+        self.stopButton.setText("Stop Run")
+        self.buttonBox.accepted.connect(self.accept)
+        self.buttonBox.rejected.connect(self.reject)
+        mainLayout.addWidget(self.buttonBox)
 
         self.setWindowTitle("Measurement Error")
         self.resize(560, 360)

--- a/src/badger/gui/windows/measurement_retry_dialog.py
+++ b/src/badger/gui/windows/measurement_retry_dialog.py
@@ -1,0 +1,54 @@
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QFont, QFontDatabase, QTextOption
+from PyQt5.QtWidgets import (
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QScrollArea,
+    QTextEdit,
+    QVBoxLayout,
+)
+
+
+class BadgerMeasurementRetryDialog(QDialog):
+    def __init__(self, text="", detailedText="", parent=None):
+        super().__init__(parent)
+        self.setWindowFlags(self.windowFlags() | Qt.WindowMaximizeButtonHint)
+
+        mainLayout = QVBoxLayout(self)
+
+        self.textLabel = QLabel(
+            text
+            + "\n\nThere was an error setting variables or getting observables."
+            + "\nRetry this measurement?"
+        )
+        self.textLabel.setMinimumWidth(320)
+        self.textLabel.setWordWrap(True)
+        font = QFont()
+        font.setBold(True)
+        self.textLabel.setFont(font)
+        mainLayout.addWidget(self.textLabel)
+
+        scrollArea = QScrollArea()
+        scrollArea.setWidgetResizable(True)
+        self.detailedTextWidget = QTextEdit(detailedText)
+        self.detailedTextWidget.setReadOnly(True)
+        self.detailedTextWidget.setWordWrapMode(QTextOption.NoWrap)
+        monoFont = QFontDatabase.systemFont(QFontDatabase.FixedFont)
+        monoFont.setPointSize(12)
+        self.detailedTextWidget.setFont(monoFont)
+        scrollArea.setWidget(self.detailedTextWidget)
+        mainLayout.addWidget(scrollArea)
+
+        buttonBox = QHBoxLayout()
+        self.retryButton = QPushButton("Retry Measurement")
+        self.stopButton = QPushButton("Stop Run")
+        self.retryButton.clicked.connect(self.accept)
+        self.stopButton.clicked.connect(self.reject)
+        buttonBox.addWidget(self.retryButton)
+        buttonBox.addWidget(self.stopButton)
+        mainLayout.addLayout(buttonBox)
+
+        self.setWindowTitle("Measurement Error")
+        self.resize(560, 360)

--- a/src/badger/tests/test_create_process.py
+++ b/src/badger/tests/test_create_process.py
@@ -43,9 +43,11 @@ def test_create_subprocess_emits_signals(qtbot, process_creator):
             "data_queue",
             "evaluate_queue",
             "wait_event",
+            "dialog_action_queue",
         }
 
         assert isinstance(emitted_args["data_queue"], mp.queues.Queue)
+        assert isinstance(emitted_args["dialog_action_queue"], mp.queues.Queue)
         assert isinstance(emitted_args["evaluate_queue"], tuple)
         assert isinstance(emitted_args["wait_event"], mp.synchronize.Event)
         assert isinstance(emitted_args["stop_event"], mp.synchronize.Event)

--- a/src/badger/tests/test_gui_basic.py
+++ b/src/badger/tests/test_gui_basic.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 from PyQt5.QtCore import QEventLoop, Qt, QTimer
+from PyQt5.QtWidgets import QDialog
 
 
 @pytest.fixture(scope="session")
@@ -128,6 +129,66 @@ def test_traceback_during_run(qtbot, init_multiprocessing):
             qtbot.wait(100)
 
         window.process_manager.close_proccesses()
+
+
+def test_measurement_retry_dialog_in_app_flow(qtbot, init_multiprocessing):
+    from badger.gui.windows.main_window import BadgerMainWindow
+    from badger.tests.utils import create_routine, fix_path_issues
+
+    fix_path_issues()
+    window = BadgerMainWindow()
+    qtbot.addWidget(window)
+
+    loop = QEventLoop()
+    QTimer.singleShot(1000, loop.quit)
+    loop.exec_()
+
+    routine = create_routine()
+    home_page = window.home_page
+    home_page.current_routine = routine
+    home_page.go_run(-1)
+    home_page.run_monitor.init_routine_runner()
+    runner = home_page.run_monitor.routine_runner
+
+    # Grab queue and process from the process manager
+    process_with_args = window.process_manager.remove_from_queue()
+    assert process_with_args is not None
+    runner.data_and_error_queue = process_with_args["data_queue"]
+    runner.dialog_action_queue = process_with_args["dialog_action_queue"]
+    runner.evaluate_queue = process_with_args["evaluate_queue"]
+    runner.routine_process = process_with_args["process"]
+
+    with patch(
+        "badger.gui.windows.measurement_retry_dialog.BadgerMeasurementRetryDialog.exec_",
+        return_value=QDialog.Accepted,
+    ) as exec_mock:
+        runner.data_and_error_queue.put(
+            {
+                "type": "measurement_error",
+                "title": "Injected measurement error",
+                "traceback": "traceback details",
+            }
+        )
+
+        # Wait up to 1 second in 10 for queue to receive the error.
+        for _ in range(10):
+            if not runner.data_and_error_queue.empty():
+                break
+            qtbot.wait(100)
+
+        # Explicitly check if any errors were thrown
+        runner.check_queue()
+
+        exec_mock.assert_called_once()
+        response = runner.dialog_action_queue.get(timeout=1)
+        assert response == {
+            "type": "measurement_action",
+            "action": "retry",
+        }
+
+    window.process_manager.close_proccesses()
+    process_with_args["process"].terminate()
+    process_with_args["process"].join()
 
 
 # TODO: Check the use_low_noise_prior parameter in the routine

--- a/src/badger/tests/test_measurement_retry_dialog.py
+++ b/src/badger/tests/test_measurement_retry_dialog.py
@@ -1,0 +1,28 @@
+from PyQt5.QtCore import QTimer
+from PyQt5.QtWidgets import QDialog
+
+
+def test_measurement_retry_dialog_retry(qtbot):
+    from badger.gui.windows.measurement_retry_dialog import (
+        BadgerMeasurementRetryDialog,
+    )
+
+    dialog = BadgerMeasurementRetryDialog(text="Test error", detailedText="traceback")
+    qtbot.addWidget(dialog)
+    assert "Test error" in dialog.textLabel.text()
+    assert "traceback" in dialog.detailedTextWidget.toPlainText()
+    QTimer.singleShot(0, dialog.retryButton.click)
+    assert dialog.exec_() == QDialog.Accepted
+
+
+def test_measurement_retry_dialog_stop(qtbot):
+    from badger.gui.windows.measurement_retry_dialog import (
+        BadgerMeasurementRetryDialog,
+    )
+
+    dialog = BadgerMeasurementRetryDialog(text="Test error", detailedText="traceback")
+    qtbot.addWidget(dialog)
+    assert "Test error" in dialog.textLabel.text()
+    assert "traceback" in dialog.detailedTextWidget.toPlainText()
+    QTimer.singleShot(0, dialog.stopButton.click)
+    assert dialog.exec_() == QDialog.Rejected


### PR DESCRIPTION
Add dialog window that allows users to retry measurements when there are errors in setting variable values / getting observables from the environment

this is an edit ontop of https://github.com/xopt-org/Badger/pull/263 (and 263 can be closed), since couldn't figure out how to push to that PR since its on the 'copilot' user's fork