### PR TITLE
bugfix for select_best

### DIFF
--- a/src/badger/gui/components/bo_visualizer/bo_widget.py
+++ b/src/badger/gui/components/bo_visualizer/bo_widget.py
@@ -22,6 +22,7 @@ from badger.gui.components.bo_visualizer.ui_components import UIComponents
 from badger.gui.components.bo_visualizer.plotting_area import PlottingArea
 from PyQt5.QtCore import Qt
 from xopt.generators.bayesian.bayesian_generator import BayesianGenerator
+from xopt.vocs import select_best
 from badger.gui.components.analysis_widget import AnalysisWidget
 
 import logging
@@ -537,8 +538,8 @@ class BOPlotWidget(AnalysisWidget):
                 "No data available in generator for selecting best reference points",
             )
 
-        index_arr, value_arr, input_params = self.routine.vocs.select_best(
-            self.generator.data
+        index_arr, value_arr, input_params = select_best(
+            self.routine.vocs, self.generator.data
         )
 
         if not index_arr or not value_arr:


### PR DESCRIPTION
This pull request refactors how the best reference points are selected in the `bo_widget.py` component of the BO visualizer. The main change is to use the standalone `select_best` function from `xopt.vocs` instead of the method on the `vocs` instance, which simplifies and standardizes the selection process.

**Refactoring and dependency updates:**

* Updated import: Now imports the `select_best` function directly from `xopt.vocs` in `bo_widget.py` to use the standalone function.
* Refactored function call: Changed the call in `set_best_reference_points` to use the standalone `select_best(vocs, data)` function instead of the previous `self.routine.vocs.select_best(self.generator.data)`.