### PR TITLE
Cap numeric library threads to 4 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ pip install badger-opt
 Currently, Badger only officially supports Linux. Badger on MacOS and
 Windows could be potentially unstable.
 
+## Thread configuration
+
+Badger caps numeric library threads (`OMP_NUM_THREADS`, `MKL_NUM_THREADS`, `OPENBLAS_NUM_THREADS`) to **4** by default. This prevents performance degradation on high-core-count machines where the default (one thread per core) causes contention for the relatively small matrix operations in Bayesian Optimization workloads.
+
+To override the default, set the environment variable before launching Badger:
+
+```shell
+export OMP_NUM_THREADS=8
+```
+
+Any value you set explicitly will be respected. Badger only fills in the cap when the variable is unset.
+
 ## Run an optimization
 
 Once Badger is installed, launch the GUI by running the following command in the terminal:

--- a/src/badger/__init__.py
+++ b/src/badger/__init__.py
@@ -1,5 +1,5 @@
 """Top-level Badger package. Exposes the version number and serves as
-the namespace root for the plugin system, database, and GUI. 
+the namespace root for the plugin system, database, and GUI.
 Also sets a cap on the library threads to 4 by default, since
 libraries auto-detect all available cores and spawn that many threads.
 This prevents performance degradation on high-core-count for

--- a/src/badger/__init__.py
+++ b/src/badger/__init__.py
@@ -1,11 +1,9 @@
-import os as _os
+import os
 
 _DEFAULT_NUM_THREADS = "4"
 
 for _var in ("OMP_NUM_THREADS", "MKL_NUM_THREADS", "OPENBLAS_NUM_THREADS"):
-    _os.environ.setdefault(_var, _DEFAULT_NUM_THREADS)
-
-del _os, _var, _DEFAULT_NUM_THREADS
+    os.environ.setdefault(_var, _DEFAULT_NUM_THREADS)
 
 try:
     from badger._version import __version__

--- a/src/badger/__init__.py
+++ b/src/badger/__init__.py
@@ -1,3 +1,12 @@
+import os as _os
+
+_DEFAULT_NUM_THREADS = "4"
+
+for _var in ("OMP_NUM_THREADS", "MKL_NUM_THREADS", "OPENBLAS_NUM_THREADS"):
+    _os.environ.setdefault(_var, _DEFAULT_NUM_THREADS)
+
+del _os, _var, _DEFAULT_NUM_THREADS
+
 try:
     from badger._version import __version__
 except ImportError:


### PR DESCRIPTION
On shared servers (e.g., lcls-srv01 with 48 cores) and kubernetes pods, libraries auto-detect all available cores and spawn that many threads. For the small matrix operations typical in Gaussian process fitting, this hurts rather than helps performance.
  
This PR:
  - Caps OMP_NUM_THREADS, MKL_NUM_THREADS, and OPENBLAS_NUM_THREADS to 4 on import, preventing performance degradation on high-core-count machines where the default (one thread per core) causes contention for
  typical BO workloads.
  - Respects any value the user has already set in their environment.
  - Adds a "Thread configuration" section to the README documenting the behavior and override.

