### PR TITLE
Update measurement retry dialog box to be visually consistent with gui

### DIFF
--- a/src/badger/gui/windows/measurement_retry_dialog.py
+++ b/src/badger/gui/windows/measurement_retry_dialog.py
@@ -1,57 +1,45 @@
-"""Dialog shown when setting variables or reading observables fails mid-run.
-Displays the error (with an expandable details pane) and asks the user whether
-to retry the measurement or stop the run."""
+"""Error dialog that allows users to retry measurements after errors in setting variable
+values / getting observables from the environment. Based on the ExpandableMessageBox dialog."""
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QFont, QFontDatabase, QTextOption
-from PyQt5.QtWidgets import (
-    QDialog,
-    QLabel,
-    QDialogButtonBox,
-    QScrollArea,
-    QTextEdit,
-    QVBoxLayout,
-)
+from PyQt5.QtWidgets import QDialogButtonBox, QMessageBox
+
+from .expandable_message_box import ExpandableMessageBox
 
 
-class BadgerMeasurementRetryDialog(QDialog):
+class BadgerMeasurementRetryDialog(ExpandableMessageBox):
     def __init__(self, text="", detailedText="", parent=None):
-        super().__init__(parent)
-        self.setWindowFlags(self.windowFlags() | Qt.WindowMaximizeButtonHint)
-
-        mainLayout = QVBoxLayout(self)
-
-        self.textLabel = QLabel(
-            text
-            + "\n\nThere was an error setting variables or getting observables."
-            + "\nRetry this measurement?"
+        full_text = (
+            "There was an error setting variables or getting observables.\n\n" + text
         )
-        self.textLabel.setMinimumWidth(320)
-        self.textLabel.setWordWrap(True)
-        font = QFont()
-        font.setBold(True)
+
+        super().__init__(
+            title="Measurement Error",
+            text=full_text,
+            detailedText=detailedText,
+            parent=parent,
+        )
+
+        self.setIcon(QMessageBox.Icon.Critical)
+
+        # Make the text big
+        font = self.textLabel.font()
+        font.setPointSize(12)
         self.textLabel.setFont(font)
-        mainLayout.addWidget(self.textLabel)
 
-        scrollArea = QScrollArea()
-        scrollArea.setWidgetResizable(True)
-        self.detailedTextWidget = QTextEdit(detailedText)
-        self.detailedTextWidget.setReadOnly(True)
-        self.detailedTextWidget.setWordWrapMode(QTextOption.WrapAnywhere)
-        monoFont = QFontDatabase.systemFont(QFontDatabase.FixedFont)
-        monoFont.setPointSize(12)
-        self.detailedTextWidget.setFont(monoFont)
-        scrollArea.setWidget(self.detailedTextWidget)
-        mainLayout.addWidget(scrollArea)
+        # So we can replace just ok button with ok+cancel buttons
+        self.okButton.hide()
 
-        self.buttonBox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
-        self.retryButton = self.buttonBox.button(QDialogButtonBox.Ok)
+        self.dialogButtonBox = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+        )
+        self.retryButton = self.dialogButtonBox.button(QDialogButtonBox.Ok)
         self.retryButton.setText("Retry Measurement")
-        self.stopButton = self.buttonBox.button(QDialogButtonBox.Cancel)
+        self.stopButton = self.dialogButtonBox.button(QDialogButtonBox.Cancel)
         self.stopButton.setText("Stop Run")
-        self.buttonBox.accepted.connect(self.accept)
-        self.buttonBox.rejected.connect(self.reject)
-        mainLayout.addWidget(self.buttonBox)
+        self.dialogButtonBox.accepted.connect(self.accept)
+        self.dialogButtonBox.rejected.connect(self.reject)
 
-        self.setWindowTitle("Measurement Error")
+        self.buttonBox.addStretch()
+        self.buttonBox.addWidget(self.dialogButtonBox)
+
         self.resize(560, 360)

--- a/src/badger/tests/test_measurement_retry_dialog.py
+++ b/src/badger/tests/test_measurement_retry_dialog.py
@@ -1,5 +1,12 @@
+import pytest
 from PyQt5.QtCore import QTimer
 from PyQt5.QtWidgets import QDialog
+
+
+# conftest suppresses ExpandableMessageBox's exec_ call, but we need it here.
+@pytest.fixture(autouse=True)
+def suppress_popups():
+    pass
 
 
 def test_measurement_retry_dialog_retry(qtbot):


### PR DESCRIPTION
makes the measurement retry dialog subclass the `expandable_message_box` so it is visually consistent to it