### PR TITLE
Fix/pydantic optional

### DIFF
--- a/src/badger/gui/components/editable_table.py
+++ b/src/badger/gui/components/editable_table.py
@@ -20,26 +20,25 @@ Useful entry points: update_items() to bulk-load state, export_data() to pull
 back only the checked rows.
 """
 
-from typing import Any, Callable, List, Dict, ParamSpec, cast
+import logging
 from functools import partial, wraps
+from typing import Any, Callable, Dict, List, ParamSpec, cast
+
+from pyparsing import TypeVar
+from PyQt5.QtCore import QRegExp, Qt, pyqtSignal
+from PyQt5.QtGui import QColor, QDragEnterEvent, QDragMoveEvent, QDropEvent
 from PyQt5.QtWidgets import (
-    QTableWidget,
-    QTableWidgetItem,
-    QHeaderView,
     QAbstractItemView,
     QCheckBox,
     QComboBox,
-    QStyledItemDelegate,
     QDoubleSpinBox,
+    QHeaderView,
     QMessageBox,
+    QStyledItemDelegate,
+    QTableWidget,
+    QTableWidgetItem,
     QWidget,
 )
-from PyQt5.QtCore import Qt, QRegExp, pyqtSignal
-from PyQt5.QtGui import QDropEvent, QDragEnterEvent, QDragMoveEvent, QColor
-
-import logging
-
-from pyparsing import TypeVar
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +104,7 @@ class EditableTable(QTableWidget):
             hheader.sectionClicked.connect(self.header_clicked)
         self.itemChanged.connect(self.on_edit_table_item)
 
-    def update_vocs(self):
+    def update_vocs(self) -> None:
         logging.debug("Emitting data_changed signal from editable_table")
         self.data_changed.emit()
 

--- a/src/badger/gui/components/env_cbox.py
+++ b/src/badger/gui/components/env_cbox.py
@@ -18,44 +18,41 @@ Environments are loaded through the plugin factory (factory.py); the combo
 box is populated from the list of available environment plugins.
 """
 
+import logging
 from importlib import resources
 from typing import Any
 
-from PyQt5.QtWidgets import (
-    QVBoxLayout,
-    QHBoxLayout,
-    QPushButton,
-    QWidget,
-    QLineEdit,
-)
+from gest_api.vocs import ContinuousVariable
+from pydantic_core import ValidationError
+from PyQt5.QtCore import QPropertyAnimation, QRegExp, pyqtSignal
+from PyQt5.QtGui import QFont, QIcon
 from PyQt5.QtWidgets import (
     QCheckBox,
-    QStyledItemDelegate,
+    QHBoxLayout,
     QLabel,
+    QLineEdit,
+    QPushButton,
     QSizePolicy,
+    QStyledItemDelegate,
+    QVBoxLayout,
+    QWidget,
 )
-from PyQt5.QtGui import QIcon, QFont
-from PyQt5.QtCore import QRegExp, QPropertyAnimation, pyqtSignal
-from pydantic_core import ValidationError
+from xopt.vocs import VOCS
 
 from badger.errors import BadgerRoutineError
 from badger.gui.components.collapsible_box import CollapsibleBox
+from badger.gui.components.con_table import ConstraintTable
+from badger.gui.components.data_table import init_data_table
+from badger.gui.components.obj_table import ObjectiveTable
+from badger.gui.components.obs_table import ObservableTable
 from badger.gui.components.pydantic_editor import BadgerPydanticEditor
 from badger.gui.components.var_table import VariableTable
-from badger.gui.components.obj_table import ObjectiveTable
-from badger.gui.components.con_table import ConstraintTable
-from badger.gui.components.obs_table import ObservableTable
-from badger.gui.components.data_table import init_data_table
-from badger.settings import init_settings
 from badger.gui.utils import (
     MouseWheelWidgetAdjustmentGuard,
     NoHoverFocusComboBox,
 )
+from badger.settings import init_settings
 from badger.utils import strtobool
-from xopt.vocs import VOCS
-from gest_api.vocs import ContinuousVariable
-
-import logging
 
 LABEL_WIDTH = 96
 ENV_PARAMS_BTN = 1  # use button or collapsible box for env parameters
@@ -538,7 +535,7 @@ class BadgerEnvBox(QWidget):
         self.sta_table.data_changed.connect(lambda: self.update_vocs("sta_table"))
         self.var_table.data_changed.connect(lambda: self.update_vocs("var_table"))
 
-    def update_vocs(self, origin: str):
+    def update_vocs(self, origin: str) -> None:
         logger.debug(f"Emitting vocs_updated signal from env_cbox: {origin}")
         vocs, _ = self.compose_vocs()
         self.vocs_updated.emit(vocs)

--- a/src/badger/gui/components/pydantic_editor.py
+++ b/src/badger/gui/components/pydantic_editor.py
@@ -1,59 +1,51 @@
-"""
-Turns a Pydantic model schema into an editable widget tree.
+"""Qt-based editor widgets for building and validating Pydantic models in the GUI."""
 
-Used in the routine editor to let users configure generator and environment
-parameters. Each field becomes the appropriate input widget (spinbox for
-numbers, checkbox for bools, nested tree for sub-models), and changes are
-validated against the Pydantic schema in real time.
-"""
-
+import ast
+import logging
+import re
 from dataclasses import dataclass
+from inspect import isclass
 from types import NoneType
 from typing import (
     Annotated,
+    Any,
     Callable,
     Optional,
-    Any,
     Sequence,
     TypeVar,
-    cast,
-    get_origin,
     Union,
+    cast,
     get_args,
+    get_origin,
 )
-from inspect import isclass
 
-from pydantic_core import PydanticUndefined
 import yaml
-from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtWidgets import (
-    QTreeWidget,
-    QTreeWidgetItem,
-    QSpinBox,
-    QDoubleSpinBox,
-    QCheckBox,
-    QLineEdit,
-    QLabel,
-    QWidget,
-    QPushButton,
-    QVBoxLayout,
-    QScrollArea,
-    QHBoxLayout,
-    QComboBox,
-    QSizePolicy,
-)
 from pydantic import BaseModel, Field, ValidationError, create_model
 from pydantic.fields import FieldInfo
+from pydantic_core import PydanticUndefined
+from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDoubleSpinBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QScrollArea,
+    QSizePolicy,
+    QSpinBox,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
 from xopt.generators import get_generator
+from xopt.generators.bayesian.bax.algorithms import Algorithm
+from xopt.generators.bayesian.bax_generator import BaxGenerator
+from xopt.generators.bayesian.bayesian_generator import BayesianGenerator
 from xopt.generators.bayesian.turbo import TurboController
 from xopt.numerical_optimizer import NumericalOptimizer
-from xopt.generators.bayesian.bayesian_generator import BayesianGenerator
-
-import re
-import ast
-
-import logging
-
 from xopt.vocs import VOCS
 
 logger = logging.getLogger(__name__)
@@ -66,19 +58,19 @@ TUPLE_PATTERN = re.compile(r"\((.*?,.*?)\)")
 
 
 class CustomSafeLoader(yaml.SafeLoader):
-    def tuple_constructor(self, node: yaml.ScalarNode | yaml.MappingNode):
-        value = self.construct_scalar(node)
+    def __init__(self, stream: Any) -> None:
+        super().__init__(stream)
+        self.add_constructor("tag:yaml.org,2002:str", type(self).tuple_constructor)
+
+    @staticmethod
+    def tuple_constructor(loader: Any, node: yaml.ScalarNode) -> Any:
+        value = loader.construct_scalar(node)
         if TUPLE_PATTERN.match(value):
             try:
                 return ast.literal_eval(value)
             except Exception:
                 pass
         return value
-
-
-CustomSafeLoader.add_constructor(
-    "tag:yaml.org,2002:str", CustomSafeLoader.tuple_constructor
-)
 
 
 def convert_to_type(value: Any, type: Callable[[Any], T]) -> T:
@@ -91,17 +83,27 @@ def convert_to_type(value: Any, type: Callable[[Any], T]) -> T:
 
 
 def _set_value_for_basic_widget(
-    widget: Any,
+    widget: QWidget,
     value: str | float | int | bool | None,
-):
+) -> None:
+    nullable = bool(widget.property("badger_nullable"))
     if isinstance(widget, QLabel) or isinstance(widget, QLineEdit):
         widget.setText("null" if value is None else str(value))
     elif isinstance(widget, QDoubleSpinBox):
-        widget.setValue(convert_to_type(value, float))
+        if value is None and nullable:
+            widget.setValue(widget.minimum())
+        else:
+            widget.setValue(convert_to_type(value, float))
     elif isinstance(widget, QSpinBox):
-        widget.setValue(convert_to_type(value, int))
+        if value is None and nullable:
+            widget.setValue(widget.minimum())
+        else:
+            widget.setValue(convert_to_type(value, int))
     elif isinstance(widget, QCheckBox):
-        widget.setChecked(convert_to_type(value, bool))
+        if value is None and nullable:
+            widget.setCheckState(Qt.CheckState.PartiallyChecked)
+        else:
+            widget.setChecked(convert_to_type(value, bool))
 
 
 @dataclass
@@ -112,7 +114,7 @@ class BadgerResolvedType:
 
     @classmethod
     def find_primary(
-        cls, annotations: list[Any] | tuple[Any, ...]
+        cls, annotations: tuple[Any, ...]
     ) -> Optional["BadgerResolvedType"]:
         if len(annotations) == 0:
             return None
@@ -156,11 +158,11 @@ class BadgerResolvedType:
         if origin == Union:
             if NoneType in args:
                 origin = Optional
-                args = [arg for arg in args if arg != NoneType]
+                args = tuple(arg for arg in args if arg != NoneType)
             else:
                 if len(args) == 1:
                     origin = args[0]
-                    args = []
+                    args = ()
                     nullable = True
 
                     if origin is not None:
@@ -177,7 +179,7 @@ class BadgerResolvedType:
 
         if origin == Optional:
             origin = args[0]
-            args = []
+            args = ()
             nullable = True
 
             if origin is not None:
@@ -208,7 +210,7 @@ class BadgerResolvedType:
         editor_info: tuple["BadgerPydanticEditor", QTreeWidgetItem] | None = None,
     ) -> QWidget | None:
         resolved_type = BadgerResolvedType.resolve(annotation)
-        widget = QLabel()
+        widget: QWidget | None = None
 
         if resolved_type.main is None:
             widget = QLineEdit()
@@ -217,6 +219,8 @@ class BadgerResolvedType:
             if issubclass(resolved_type.main, TurboController):
                 widget = QComboBox()
             elif issubclass(resolved_type.main, NumericalOptimizer):
+                widget = QComboBox()
+            elif issubclass(resolved_type.main, Algorithm):
                 widget = QComboBox()
             else:
                 return None
@@ -283,23 +287,43 @@ class BadgerResolvedType:
             widget = QDoubleSpinBox()
             widget.setRange(float("-inf"), float("inf"))
             widget.setDecimals(6)
-            value = convert_to_type(default, float) if default is not None else 0.0
-            widget.setValue(value)
+            if resolved_type.nullable:
+                # The minimum value doubles as the "null" sentinel.
+                widget.setSpecialValueText("null")
+            if default is not None:
+                widget.setValue(convert_to_type(default, float))
+            elif resolved_type.nullable:
+                widget.setValue(widget.minimum())
+            else:
+                widget.setValue(0.0)
 
             if editor_info is not None:
                 widget.valueChanged.connect(lambda: handle_changed(editor_info))
         elif resolved_type.main is int:
             widget = QSpinBox()
             widget.setRange(-(2**31), 2**31 - 1)  # int32 min/max
-            value = convert_to_type(default, int) if default is not None else 0
-            widget.setValue(value)
+            if resolved_type.nullable:
+                # The minimum value doubles as the "null" sentinel.
+                widget.setSpecialValueText("null")
+            if default is not None:
+                widget.setValue(convert_to_type(default, int))
+            elif resolved_type.nullable:
+                widget.setValue(widget.minimum())
+            else:
+                widget.setValue(0)
 
             if editor_info is not None:
                 widget.valueChanged.connect(lambda: handle_changed(editor_info))
         elif resolved_type.main is bool:
             widget = QCheckBox()
-            value = convert_to_type(default, bool) if default is not None else False
-            widget.setChecked(value)
+            if resolved_type.nullable:
+                widget.setTristate(True)
+            if default is not None:
+                widget.setChecked(convert_to_type(default, bool))
+            elif resolved_type.nullable:
+                widget.setCheckState(Qt.CheckState.PartiallyChecked)
+            else:
+                widget.setChecked(False)
 
             if editor_info is not None:
                 widget.stateChanged.connect(lambda: handle_changed(editor_info))
@@ -317,7 +341,7 @@ class BadgerResolvedType:
         return widget
 
 
-def handle_changed(editor_info: tuple["BadgerPydanticEditor", QTreeWidgetItem]):
+def handle_changed(editor_info: tuple["BadgerPydanticEditor", QTreeWidgetItem]) -> None:
     tree_widget, _ = editor_info
     tree_widget.validate()
 
@@ -328,22 +352,26 @@ def _qt_widget_to_yaml_value(widget: Any) -> str | None:
     elif isinstance(widget, BadgerListEditor):
         return widget.get_parameters_yaml()
     elif isinstance(widget, QSpinBox) or isinstance(widget, QDoubleSpinBox):
+        if widget.property("badger_nullable") and widget.value() == widget.minimum():
+            return "null"
         return str(widget.value())
     elif isinstance(widget, QCheckBox):
+        if (
+            widget.property("badger_nullable")
+            and widget.checkState() == Qt.CheckState.PartiallyChecked
+        ):
+            return "null"
         return "true" if widget.isChecked() else "false"
     elif isinstance(widget, QComboBox):
         if widget.currentText() == "null":
             return "null"
         return f'"{widget.currentText()}"'
     elif isinstance(widget, (QLabel, QLineEdit)):
-        if widget.text() == "null" or widget.text() == "None":
-            return '"null"'
+        text = widget.text()
+        if text == "null" or text == "None" or text == "":
+            return "null"
         else:
-            return (
-                ('"' + widget.text() + '"')
-                if isinstance(widget, QLineEdit)
-                else widget.text()
-            )
+            return ('"' + text + '"') if isinstance(widget, QLineEdit) else text
     return "null"
 
 
@@ -387,8 +415,15 @@ def _qt_widget_to_value(widget: Any) -> Any:
     elif isinstance(widget, BadgerListEditor):
         return widget.get_parameters_dict()
     elif isinstance(widget, QSpinBox) or isinstance(widget, QDoubleSpinBox):
+        if widget.property("badger_nullable") and widget.value() == widget.minimum():
+            return None
         return widget.value()
     elif isinstance(widget, QCheckBox):
+        if (
+            widget.property("badger_nullable")
+            and widget.checkState() == Qt.CheckState.PartiallyChecked
+        ):
+            return None
         return widget.isChecked()
     elif isinstance(widget, QComboBox):
         return widget.currentText()
@@ -436,7 +471,6 @@ class BadgerListItem(QWidget):
                 QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
             )
             if isinstance(self.parameter_value, QLineEdit):
-                self.parameter_value = cast(QLineEdit, self.parameter_value)
                 self.parameter_value.editingFinished.connect(
                     lambda: self.editor.listChanged.emit()
                 )
@@ -453,7 +487,6 @@ class BadgerListItem(QWidget):
                 )
 
                 if isinstance(self.parameter_value2, QDoubleSpinBox):
-                    self.parameter_value2 = cast(QDoubleSpinBox, self.parameter_value2)
                     self.parameter_value2.valueChanged.connect(
                         lambda: self.editor.listChanged.emit()
                     )
@@ -467,13 +500,13 @@ class BadgerListItem(QWidget):
         remove_button.clicked.connect(self.remove)
         layout.addWidget(remove_button, alignment=Qt.AlignmentFlag.AlignRight)
 
-    def parameter1(self):
+    def parameter1(self) -> QWidget | None:
         return self.parameter_value
 
-    def parameter2(self):
+    def parameter2(self) -> QWidget | None:
         return self.parameter_value2
 
-    def remove(self):
+    def remove(self) -> None:
         self.setParent(None)
         self.deleteLater()
         self.editor.listChanged.emit()
@@ -513,16 +546,16 @@ class BadgerListEditor(QWidget):
 
         layout.addLayout(button_layout)
 
-    def handle_button_click(self):
+    def handle_button_click(self) -> None:
         self.add_widget()
 
-    def add_widget(self):
+    def add_widget(self) -> BadgerListItem:
         widget = BadgerListItem(self)
         self.list_layout.addWidget(widget)
         self.listChanged.emit()
         return widget
 
-    def get_parameters_yaml(self):
+    def get_parameters_yaml(self) -> str | None:
         child_values: list[str | None] = [
             _qt_widget_to_yaml_value(child.parameter_value)
             for child in self.list_container.children()
@@ -548,7 +581,7 @@ class BadgerListEditor(QWidget):
                 + "}"
             )
 
-    def get_parameters_dict(self):
+    def get_parameters_dict(self) -> dict[str, Any] | None:
         child_values: list[str | None] = [
             _qt_widget_to_value(child.parameter_value)
             for child in self.list_container.children()
@@ -602,7 +635,7 @@ class BadgerPydanticEditor(QTreeWidget):
         fields: dict[str, FieldInfo],
         defaults: dict[str, Any] | None,
         hidden: bool,
-    ):
+    ) -> None:
         for field_name, field_info in fields.items():
             child = QTreeWidgetItem(
                 [field_name if i == 0 else "" for i in range(0, self.value_col + 1)]
@@ -612,7 +645,8 @@ class BadgerPydanticEditor(QTreeWidget):
                 self.addTopLevelItem(child)
             else:
                 parent.addChild(child)
-            child.setToolTip(0, field_info.description)
+            if field_info.description:
+                child.setToolTip(0, field_info.description)
 
             widget = BadgerResolvedType.resolve_qt(
                 annotation=field_info.annotation,
@@ -654,27 +688,30 @@ class BadgerPydanticEditor(QTreeWidget):
         self,
         widget: QComboBox,
         selections: Sequence[type[BaseModel] | None],
-    ):
+    ) -> None:
         # Clear out existing children
         widget.clear()
         for selection in selections:
             if selection is None:
                 widget.addItem("null", selection)
             else:
+                logger.debug(
+                    f"Adding selection {selection} with name {selection.model_fields['name'].default} to combo box"
+                )
                 widget.addItem(selection.model_fields["name"].default, selection)
 
-    def set_params_from_class(self, pydantic_class: type[Any]):
+    def set_params_from_class(self, pydantic_class: type[Any]) -> None:
         self.clear()
         self.model_class = pydantic_class
         self._set_params_recurse(None, self.model_class.model_fields, None, False)
         self.set_params_post_setup({})
         self.validate()
 
-    def set_params_from_dict(self, params: dict[str, Any]):
+    def set_params_from_dict(self, params: dict[str, Any]) -> None:
         self.clear()
         field_definitions: dict[str, tuple[type, FieldInfo]] = {
             k: (type(v), Field()) for k, v in params.items()
-        }  # type: ignore
+        }
         if field_definitions == {}:
             logger.warning("No fields found in params dictionary")
             return
@@ -693,7 +730,7 @@ class BadgerPydanticEditor(QTreeWidget):
         defaults: dict[str, Any],
         vocs: VOCS | None = None,
         validate: bool = True,
-    ):
+    ) -> None:
         logger.debug(f"vocs: {vocs}")
         logger.debug(f"defaults: {defaults}")
         self.vocs = vocs or VOCS(variables={})
@@ -731,7 +768,7 @@ class BadgerPydanticEditor(QTreeWidget):
         if validate:
             self.validate()
 
-    def set_params_post_setup(self, defaults: dict[str, Any]):
+    def set_params_post_setup(self, defaults: dict[str, Any]) -> None:
         if self.model_class is None:
             raise ValueError("Model class is not set.")
 
@@ -742,7 +779,14 @@ class BadgerPydanticEditor(QTreeWidget):
             if self.model_class.model_fields.get("numerical_optimizer") is not None:
                 self.initialize_special_field(defaults, "numerical_optimizer")
 
-    def initialize_special_field(self, defaults: dict[str, Any], field: str):
+            if issubclass(self.model_class, BaxGenerator):
+                logger.debug(
+                    f"Generator is a {self.model_class.__name__} checking for algorithm field."
+                )
+                if self.model_class.model_fields.get("algorithm") is not None:
+                    self.initialize_special_field(defaults, "algorithm")
+
+    def initialize_special_field(self, defaults: dict[str, Any], field: str) -> None:
         widget_items = self.findItems(field, Qt.MatchFlag.MatchExactly)
 
         if len(widget_items) == 0:
@@ -757,7 +801,6 @@ class BadgerPydanticEditor(QTreeWidget):
         widget = self.itemWidget(special_item, self.value_col)
         if widget is None or not isinstance(widget, QComboBox):
             raise ValueError(f"{field} does not have a combo box widget.")
-        widget = cast(QComboBox, widget)
 
         selections = self.get_all_compatible_classes(field)
 
@@ -787,10 +830,12 @@ class BadgerPydanticEditor(QTreeWidget):
         )
 
         widget.currentIndexChanged.connect(
-            lambda: self.on_radio_changed(special_item, "turbo_controller")
+            lambda: self.on_radio_changed(special_item, field)
         )
 
-    def get_all_compatible_classes(self, field_name: str):
+    def get_all_compatible_classes(
+        self, field_name: str
+    ) -> Sequence[type[BaseModel] | None]:
         if self.model_class is None:
             raise ValueError("Model class is not set.")
 
@@ -804,6 +849,10 @@ class BadgerPydanticEditor(QTreeWidget):
             if not issubclass(self.model_class, BayesianGenerator):
                 raise ValueError("Generator does not support turbo controllers.")
             compatible_classes = self.model_class.get_compatible_turbo_controllers()
+        elif field_name == "algorithm":
+            if not issubclass(self.model_class, BaxGenerator):
+                raise ValueError("Generator does not support algorithms.")
+            compatible_classes = self.model_class.get_compatible_algorithms()
         else:
             raise ValueError(f"Field name {field_name} is not recognized.")
 
@@ -825,7 +874,7 @@ class BadgerPydanticEditor(QTreeWidget):
 
         if selected_class is None:
             raise ValueError(
-                f"Generator has numerical optimizer set but no compatible numerical optimizer with name {name} exists."
+                f"Generator has {field_name} set but no compatible {field_name} with name {name} exists."
             )
 
         return selected_class
@@ -834,7 +883,7 @@ class BadgerPydanticEditor(QTreeWidget):
         self,
         tree_widget_item: QTreeWidgetItem,
         field_name: str,
-    ):
+    ) -> None:
         # Clear out existing children
         for cc in tree_widget_item.takeChildren():
             del cc
@@ -842,7 +891,6 @@ class BadgerPydanticEditor(QTreeWidget):
         widget = self.itemWidget(tree_widget_item, self.value_col)
         if widget is None or not isinstance(widget, QComboBox):
             raise ValueError("tree widget item does not have a combo box widget.")
-        widget = cast(QComboBox, widget)
 
         name = widget.currentText()
         if name == "null":
@@ -866,7 +914,7 @@ class BadgerPydanticEditor(QTreeWidget):
         name: str,
         field_name: str,
         defaults: dict[str, Any],
-    ):
+    ) -> None:
         try:
             pydantic_class = self.get_compatible_class(name, field_name)
         except ValueError:
@@ -929,7 +977,7 @@ class BadgerPydanticEditor(QTreeWidget):
         return filtered_class_fields, removed_class_fields
 
     @staticmethod
-    def get_defaults_from_type(pydantic_class: type[Any]):
+    def get_defaults_from_type(pydantic_class: type[Any]) -> dict[str, Any]:
         if not issubclass(pydantic_class, BaseModel):
             raise ValueError("Provided class is not a Pydantic model")
         defaults: dict[str, Any] = {}
@@ -981,7 +1029,7 @@ class BadgerPydanticEditor(QTreeWidget):
 
         return None
 
-    def remove_style(self, item: QTreeWidgetItem | None):
+    def remove_style(self, item: QTreeWidgetItem | None) -> None:
         # Have to reset border styling in case some errors were fixed
         if item is None:
             return
@@ -993,7 +1041,7 @@ class BadgerPydanticEditor(QTreeWidget):
         for j in range(item.childCount()):
             self.remove_style(item.child(j))
 
-    def update_vocs(self, vocs: VOCS):
+    def update_vocs(self, vocs: VOCS) -> None:
         logger.debug(f"Updating VOCS in BadgerPydanticEditor: {vocs}")
         self.vocs = vocs
 
@@ -1005,7 +1053,7 @@ class BadgerPydanticEditor(QTreeWidget):
         self.set_params_from_generator(self.generator_name, defaults, self.vocs)
         self.validate()
 
-    def update_after_validate(self, defaults: dict[str, Any]):
+    def update_after_validate(self, defaults: dict[str, Any]) -> None:
         model_class = self.model_class
         if model_class is None:
             return
@@ -1038,9 +1086,48 @@ class BadgerPydanticEditor(QTreeWidget):
         if self.update_callback is not None:
             self.update_callback(self)
 
-    def validate(self):
+    def _inject_computed_fields(
+        self,
+        parameters_dict: Any,
+        model_class: type[BaseModel],
+    ) -> None:
+        # Pydantic @computed_field values aren't editable in the form, but some
+        # validators (e.g. Xopt's discriminated-union dispatch on `class_path`)
+        # require them in the input dict. Walk the dict, derive each level's
+        # computed fields from its pydantic class, and inject them.
+        if not isinstance(parameters_dict, dict):
+            return
+
+        try:
+            instance = model_class.model_construct(**parameters_dict)
+            for cf_name in model_class.model_computed_fields:
+                if cf_name in parameters_dict:
+                    continue
+                try:
+                    parameters_dict[cf_name] = getattr(instance, cf_name)
+                except Exception as e:
+                    logger.debug(
+                        f"Could not compute {cf_name} on {model_class.__name__}: {e}"
+                    )
+        except Exception as e:
+            logger.debug(
+                f"Could not model_construct {model_class.__name__} for computed-field injection: {e}"
+            )
+
+        if isclass(model_class) and issubclass(model_class, BayesianGenerator):
+            for sub_field in ("algorithm", "numerical_optimizer", "turbo_controller"):
+                sub = parameters_dict.get(sub_field)
+                if not isinstance(sub, dict) or "name" not in sub:
+                    continue
+                try:
+                    sub_class = self.get_compatible_class(sub["name"], sub_field)
+                except (ValueError, AttributeError):
+                    continue
+                self._inject_computed_fields(sub, sub_class)
+
+    def validate(self) -> bool:
         if self.model_class is None:
-            return False
+            raise ValueError("Model class is not set.")
 
         self.setStyleSheet("")
         for i in range(self.topLevelItemCount()):
@@ -1050,7 +1137,7 @@ class BadgerPydanticEditor(QTreeWidget):
             parameters = self.get_parameters_yaml()
             parameters_dict = yaml.load(parameters, Loader=CustomSafeLoader)
 
-            def convert_dict(val):
+            def convert_dict(val: Any) -> Any:
                 # Convert str-encoded dicts (and lists) back into actual dict objects."""
                 if isinstance(val, str):
                     stripped = val.strip()
@@ -1077,10 +1164,9 @@ class BadgerPydanticEditor(QTreeWidget):
 
             # Not valid unlesss has at least one objective
             if "vocs" not in parameters_dict:
-                return False
-            obj_data = parameters_dict["vocs"].get("objectives")
-            if not obj_data or len(obj_data) == 0:
-                return False
+                raise KeyError("vocs field is required in parameters")
+
+            self._inject_computed_fields(parameters_dict, self.model_class)
 
             model = self.model_class.model_validate(parameters_dict)
 
@@ -1094,14 +1180,19 @@ class BadgerPydanticEditor(QTreeWidget):
             self.update_after_validate(defaults)
 
             return True
+
         except KeyError as e:
             logger.error(e)
+            return False
         except ValidationError as e:
             logger.error(e)
 
             for error in e.errors():
                 loc = error["loc"]
                 msg = error["msg"]
+                error_widget: (
+                    QTreeWidgetItem | QTreeWidget | "BadgerPydanticEditor" | None
+                ) = None
                 if len(loc) > 0:
                     error_widget = self.find_widget_at_path(loc)
                 else:
@@ -1116,7 +1207,6 @@ class BadgerPydanticEditor(QTreeWidget):
                                 '*[error="true"] { border: 2px dashed red }'
                             )
                             if isinstance(widget, BadgerListEditor):
-                                widget = cast(BadgerListEditor, widget)
                                 widget.list_container.setProperty("error", True)
                                 widget.list_container.setStyleSheet(
                                     '*[error="true"] { border: 2px dashed red }'

--- a/src/badger/gui/components/pydantic_editor.py
+++ b/src/badger/gui/components/pydantic_editor.py
@@ -40,6 +40,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+from xopt.errors import VOCSError
 from xopt.generators import get_generator
 from xopt.generators.bayesian.bax.algorithms import Algorithm
 from xopt.generators.bayesian.bax_generator import BaxGenerator
@@ -1125,7 +1126,7 @@ class BadgerPydanticEditor(QTreeWidget):
                     continue
                 self._inject_computed_fields(sub, sub_class)
 
-    def validate(self) -> bool:
+    def validate(self) -> None:
         if self.model_class is None:
             raise ValueError("Model class is not set.")
 
@@ -1161,13 +1162,10 @@ class BadgerPydanticEditor(QTreeWidget):
                         parameters_dict["vocs"][key] = convert_dict(
                             parameters_dict["vocs"][key]
                         )
-
-            # Not valid unlesss has at least one objective
-            if "vocs" not in parameters_dict:
+            else:
                 raise KeyError("vocs field is required in parameters")
 
             self._inject_computed_fields(parameters_dict, self.model_class)
-
             model = self.model_class.model_validate(parameters_dict)
 
             # After we validate the model, some fields may have been changed due to any validation logic present within the Pydantic model (i.e. field validators changing default values). We need to update the tree to reflect these changes.
@@ -1179,45 +1177,45 @@ class BadgerPydanticEditor(QTreeWidget):
 
             self.update_after_validate(defaults)
 
-            return True
-
         except KeyError as e:
             logger.error(e)
-            return False
+        except VOCSError as e:
+            logger.error(e)
+            loc: tuple[int | str, ...] = ("vocs",)
+            msg = e.message if hasattr(e, "message") else str(e)
+            self.update_error_styles(loc, msg)
         except ValidationError as e:
             logger.error(e)
 
             for error in e.errors():
                 loc = error["loc"]
                 msg = error["msg"]
-                error_widget: (
-                    QTreeWidgetItem | QTreeWidget | "BadgerPydanticEditor" | None
-                ) = None
-                if len(loc) > 0:
-                    error_widget = self.find_widget_at_path(loc)
-                else:
-                    error_widget = self
-                if error_widget:
-                    if type(error_widget) is QTreeWidgetItem:
-                        error_widget.setBackground(0, Qt.GlobalColor.red)
-                        widget = self.itemWidget(error_widget, self.value_col)
-                        if widget is not None:
-                            widget.setProperty("error", True)
-                            widget.setStyleSheet(
-                                '*[error="true"] { border: 2px dashed red }'
-                            )
-                            if isinstance(widget, BadgerListEditor):
-                                widget.list_container.setProperty("error", True)
-                                widget.list_container.setStyleSheet(
-                                    '*[error="true"] { border: 2px dashed red }'
-                                )
+                self.update_error_styles(loc, msg)
 
-                        error_widget.setToolTip(0, msg)
-                    else:
-                        error_widget = cast(QTreeWidget, error_widget)
-                        error_widget.setProperty("error", True)
-                        error_widget.setStyleSheet(
+    def update_error_styles(self, loc: tuple[int | str, ...], msg: str) -> None:
+        error_widget: QTreeWidgetItem | QTreeWidget | "BadgerPydanticEditor" | None = (
+            None
+        )
+        if len(loc) > 0:
+            error_widget = self.find_widget_at_path(loc)
+        else:
+            error_widget = self
+        if error_widget:
+            if type(error_widget) is QTreeWidgetItem:
+                error_widget.setBackground(0, Qt.GlobalColor.red)
+                widget = self.itemWidget(error_widget, self.value_col)
+                if widget is not None:
+                    widget.setProperty("error", True)
+                    widget.setStyleSheet('*[error="true"] { border: 2px dashed red }')
+                    if isinstance(widget, BadgerListEditor):
+                        widget.list_container.setProperty("error", True)
+                        widget.list_container.setStyleSheet(
                             '*[error="true"] { border: 2px dashed red }'
                         )
-                        error_widget.setToolTip(msg)
-            return False
+
+                error_widget.setToolTip(0, msg)
+            else:
+                error_widget = cast(QTreeWidget, error_widget)
+                error_widget.setProperty("error", True)
+                error_widget.setStyleSheet('*[error="true"] { border: 2px dashed red }')
+                error_widget.setToolTip(msg)

--- a/src/badger/gui/components/pydantic_editor.py
+++ b/src/badger/gui/components/pydantic_editor.py
@@ -1,4 +1,11 @@
-"""Qt-based editor widgets for building and validating Pydantic models in the GUI."""
+"""
+Turns a Pydantic model schema into an editable widget tree.
+
+Used in the routine editor to let users configure generator and environment
+parameters. Each field becomes the appropriate input widget (spinbox for
+numbers, checkbox for bools, nested tree for sub-models), and changes are
+validated against the Pydantic schema in real time.
+"""
 
 import ast
 import logging

--- a/src/badger/gui/pages/home_page.py
+++ b/src/badger/gui/pages/home_page.py
@@ -11,57 +11,54 @@ results in the monitor.
 """
 
 import gc
+import logging
 import os
 import traceback
 from importlib import resources
 
 import numpy as np
 from pandas import DataFrame
-from PyQt5.QtCore import pyqtSignal, Qt, QModelIndex
+from PyQt5.QtCore import QModelIndex, Qt, pyqtSignal
 from PyQt5.QtGui import QIcon, QKeySequence
 from PyQt5.QtWidgets import (
+    QLabel,
     QMessageBox,
     QShortcut,
     QSplitter,
+    QTabWidget,
     QVBoxLayout,
     QWidget,
-    QLabel,
-    QTabWidget,
 )
 
 from badger.archive import (
     delete_run,
     get_base_run_filename,
-    load_run,
     get_runs,
+    load_run,
     save_tmp_run,
 )
+from badger.errors import BadgerRoutineError
+from badger.gui.components.action_bar import BadgerActionBar
+from badger.gui.components.data_panel import filter_metadata
 from badger.gui.components.data_table import (
     add_row,
     data_table,
     reset_table,
     update_table,
 )
-
-from badger.gui.components.navigators import HistoryNavigator
-from badger.gui.components.navigators import TemplateNavigator
+from badger.gui.components.navigators import HistoryNavigator, TemplateNavigator
 from badger.gui.components.routine_page import BadgerRoutinePage
 from badger.gui.components.run_monitor import BadgerOptMonitor
 from badger.gui.components.status_bar import BadgerStatusBar
-from badger.gui.components.action_bar import BadgerActionBar
-from badger.gui.components.data_panel import filter_metadata
-from badger.utils import get_header
-from badger.settings import init_settings
+from badger.gui.utils import ModalOverlay
 
 # from PyQt5.QtGui import QBrush, QColor
 from badger.gui.windows.message_dialog import BadgerScrollableMessageBox
 from badger.gui.windows.terminition_condition_dialog import (
     BadgerTerminationConditionDialog,
 )
-from badger.gui.utils import ModalOverlay
-from badger.errors import BadgerRoutineError
-
-import logging
+from badger.settings import init_settings
+from badger.utils import get_header
 
 logger = logging.getLogger(__name__)
 
@@ -153,13 +150,11 @@ class BadgerHomePage(QWidget):
         vbox_table = QVBoxLayout(panel_table)
         vbox_table.setContentsMargins(0, 0, 0, 0)
         title_label = QLabel("Run Data")
-        title_label.setStyleSheet(
-            """
+        title_label.setStyleSheet("""
             background-color: #455364;
             font-weight: bold;
             padding: 4px;
-        """
-        )
+        """)
         title_label.setAlignment(Qt.AlignCenter)  # Center-align the title
         vbox_table.addWidget(title_label, 0)
         self.run_table = run_table = data_table()

--- a/src/badger/tests/test_routine_page.py
+++ b/src/badger/tests/test_routine_page.py
@@ -1,15 +1,16 @@
 import json
+
 import pandas as pd
 import pytest
-from pytestqt.qtbot import QtBot
-from PyQt5.QtCore import Qt, QTimer
-from PyQt5.QtWidgets import QApplication
 from gest_api.vocs import (
-    LessThanConstraint,
     ContinuousVariable,
+    LessThanConstraint,
     MinimizeObjective,
     Observable,
 )
+from PyQt5.QtCore import Qt, QTimer
+from PyQt5.QtWidgets import QApplication
+from pytestqt.qtbot import QtBot
 
 
 def test_routine_page_init(qtbot: QtBot):
@@ -32,10 +33,10 @@ def test_set_routine(qtbot: QtBot):
 
 def test_routine_generation(qtbot: QtBot):
     from badger.errors import BadgerRoutineError
-    from badger.utils import get_badger_version, get_xopt_version
 
     # test if a simple routine can be created
     from badger.gui.components.routine_page import BadgerRoutinePage
+    from badger.utils import get_badger_version, get_xopt_version
 
     window = BadgerRoutinePage()
     qtbot.addWidget(window)
@@ -189,8 +190,8 @@ def test_constraints(qtbot: QtBot):
     window = BadgerRoutinePage()
     qtbot.addWidget(window)
 
-    qtbot.keyClicks(window.generator_box.cb, "expected_improvement")
     qtbot.keyClicks(window.env_box.cb, "test")
+    qtbot.keyClicks(window.generator_box.cb, "expected_improvement")
 
     # click checkbox to select vars/objectives
     window.env_box.var_table.cellWidget(0, 0).setChecked(True)


### PR DESCRIPTION
Addresses failing tests due to Optional fields being assigned improper values by default in the BadgerPydanticEditor used in the algorithm tab.

- Changed how `VOCSErrors` are handled to address any errors with environment more gracefully
- Fixed error in validation logic that was would exit validate before any pydantic validation happened
- Fixed logic when handling `Optional` fields in pydantic classes that would set default values regardless even if None is acceptable
- Added python type hints to touched files to improve maintainability