### PR TITLE
update xopt call to get_local_region

### DIFF
--- a/src/badger/gui/components/routine_page.py
+++ b/src/badger/gui/components/routine_page.py
@@ -48,7 +48,7 @@ from xopt.generators import (
     all_generator_names,
     get_generator_dynamic,
 )
-from xopt.utils import get_local_region
+from xopt.vocs import get_local_region
 from gest_api.vocs import (
     BaseConstraint,
     BaseObjective,
@@ -1311,7 +1311,7 @@ class BadgerRoutinePage(QWidget):
 
         n_point = add_rand_config["n_points"]
         fraction = add_rand_config["fraction"]
-        random_sample_region = get_local_region(var_curr, vocs, fraction=fraction)
+        random_sample_region = get_local_region(vocs, var_curr, fraction=fraction)
         with warnings.catch_warnings(record=True) as caught_warnings:
             try:
                 random_points = random_inputs(

--- a/src/badger/routine.py
+++ b/src/badger/routine.py
@@ -28,7 +28,7 @@ from pydantic import (
 )
 from xopt import Evaluator, VOCS, Xopt
 from xopt.generators import get_generator
-from xopt.utils import get_local_region
+from xopt.vocs import get_local_region
 from xopt.generators.sequential import SequentialGenerator
 from badger.utils import curr_ts
 from badger.environment import BaseEnvironment, instantiate_env
@@ -259,7 +259,7 @@ def calculate_initial_points(init_actions, vocs, env):
             var_curr = env.get_variables(vnames)
             n_point = action["config"]["n_points"]
             fraction = action["config"]["fraction"]
-            random_sample_region = get_local_region(var_curr, vocs, fraction=fraction)
+            random_sample_region = get_local_region(vocs, var_curr, fraction=fraction)
             random_points = vocs.random_inputs(
                 n_point, custom_bounds=random_sample_region
             )


### PR DESCRIPTION
This pull request updates the import path and usage of the `get_local_region` function throughout the codebase to reflect its new location and argument order. The changes ensure compatibility with the updated `xopt` library and correct the function's invocation.

**Dependency updates:**

* Updated all imports to use `get_local_region` from `xopt.vocs` instead of `xopt.utils` in both `routine_page.py` and `routine.py`. [[1]](diffhunk://#diff-71ebbdbeb0853016c5ff1406753c1b0b16a37be2f472ce196d2c7d4a2d240b55L51-R51) [[2]](diffhunk://#diff-f958ed207a77efc623c802368ff3689c99c5ff0fe012d74c2faa4abd4c8446ffL31-R31)

**Bug fixes / API usage:**

* Changed the order of arguments when calling `get_local_region` to match the new signature: now passing `vocs` as the first argument and `var_curr` as the second, in both `add_rand_in_init_table` and `calculate_initial_points`. [[1]](diffhunk://#diff-71ebbdbeb0853016c5ff1406753c1b0b16a37be2f472ce196d2c7d4a2d240b55L1314-R1314) [[2]](diffhunk://#diff-f958ed207a77efc623c802368ff3689c99c5ff0fe012d74c2faa4abd4c8446ffL262-R262)