### PR TITLE
Show warning message for NaN vars in select_env

### DIFF
--- a/src/badger/gui/mini/components/env_cbox.py
+++ b/src/badger/gui/mini/components/env_cbox.py
@@ -27,6 +27,7 @@ from PyQt5.QtWidgets import (
     QLabel,
 )
 from PyQt5.QtCore import QRegExp, pyqtSignal
+import numpy as np
 from badger.gui.components.obs_table import ObservableTable
 from badger.settings import init_settings
 from pydantic_core import ValidationError
@@ -658,6 +659,15 @@ class BadgerEnvBox(QWidget):
                 _variables.append(var)
 
         self.var_table.update_variables(_variables, 1)
+
+    def get_nan_vars(self) -> list[str]:
+        """Return keys of var_table entries with NaN values"""
+        current_values = self.var_table.current_values
+        return [
+            key
+            for key, value in current_values.items()
+            if isinstance(value, (float, np.floating)) and np.isnan(value)
+        ]
 
     def toggle_obj_show_mode(self, _):
         self.obj_table.update_show_selected_only(self.check_only_obj.isChecked())

--- a/src/badger/gui/mini/pages/routine_page.py
+++ b/src/badger/gui/mini/pages/routine_page.py
@@ -1187,18 +1187,13 @@ class BadgerRoutinePage(QWidget):
         self.check_for_nan_vars()
 
     def check_for_nan_vars(self) -> None:
-        """Check whether any var_table values are NaN and raise error to notify user"""
-        current_values = self.env_box.var_table.current_values
-        nan_value_keys = [
-            key
-            for key, value in current_values.items()
-            if isinstance(value, (float, np.floating)) and np.isnan(value)
-        ]
+        """Show a warning popup to notify user if any var_table values are NaN"""
+        nan_value_keys = self.env_box.get_nan_vars()
         if nan_value_keys:
             nan_vars = "\n".join(f" -  {key}" for key in nan_value_keys)
             QMessageBox.warning(
                 self,
-                "Unable to connect to some variables",
+                "Variables with invalid values",
                 f"Failed to get values for the following variables:\n{nan_vars}",
             )
 

--- a/src/badger/gui/mini/pages/routine_page.py
+++ b/src/badger/gui/mini/pages/routine_page.py
@@ -8,7 +8,6 @@ to run. It also supports the reverse path (refresh_ui/set_routine) to load
 an existing Routine back into the form.
 """
 
-import math
 from typing import Any
 import warnings
 import traceback
@@ -1190,11 +1189,13 @@ class BadgerRoutinePage(QWidget):
     def check_for_nan_vars(self):
         current_values = self.env_box.var_table.current_values
         nan_value_keys = [
-            key for key in current_values if math.isnan(current_values[key])
+            key
+            for key, value in current_values.items()
+            if isinstance(value, (float, np.floating)) and np.isnan(value)
         ]
         if len(nan_value_keys):
             raise BadgerEnvVarError(
-                "Failed to connect or get values for the following variables:\n"
+                "Failed to get values for the following variables:\n"
                 + f"{nan_value_keys}"
             )
 

--- a/src/badger/gui/mini/pages/routine_page.py
+++ b/src/badger/gui/mini/pages/routine_page.py
@@ -1194,9 +1194,12 @@ class BadgerRoutinePage(QWidget):
             for key, value in current_values.items()
             if isinstance(value, (float, np.floating)) and np.isnan(value)
         ]
-        if len(nan_value_keys):
-            raise BadgerEnvVarError(
-                f"Failed to get values for the following variables:\n{nan_value_keys}"
+        if nan_value_keys:
+            nan_vars = "\n".join(f" -  {key}" for key in nan_value_keys)
+            QMessageBox.warning(
+                self,
+                "Unable to connect to some variables",
+                f"Failed to get values for the following variables:\n{nan_vars}",
             )
 
     def get_init_table_header(self):

--- a/src/badger/gui/mini/pages/routine_page.py
+++ b/src/badger/gui/mini/pages/routine_page.py
@@ -1186,7 +1186,8 @@ class BadgerRoutinePage(QWidget):
 
         self.check_for_nan_vars()
 
-    def check_for_nan_vars(self):
+    def check_for_nan_vars(self) -> None:
+        """Check whether any var_table values are NaN and raise error to notify user"""
         current_values = self.env_box.var_table.current_values
         nan_value_keys = [
             key
@@ -1195,8 +1196,7 @@ class BadgerRoutinePage(QWidget):
         ]
         if len(nan_value_keys):
             raise BadgerEnvVarError(
-                "Failed to get values for the following variables:\n"
-                + f"{nan_value_keys}"
+                f"Failed to get values for the following variables:\n{nan_value_keys}"
             )
 
     def get_init_table_header(self):

--- a/src/badger/gui/mini/pages/routine_page.py
+++ b/src/badger/gui/mini/pages/routine_page.py
@@ -8,6 +8,7 @@ to run. It also supports the reverse path (refresh_ui/set_routine) to load
 an existing Routine back into the form.
 """
 
+import math
 from typing import Any
 import warnings
 import traceback
@@ -1183,6 +1184,19 @@ class BadgerRoutinePage(QWidget):
 
         # Update the docs
         self.window_env_docs.update_docs(env.name, "environment")
+
+        self.check_for_nan_vars()
+
+    def check_for_nan_vars(self):
+        current_values = self.env_box.var_table.current_values
+        nan_value_keys = [
+            key for key in current_values if math.isnan(current_values[key])
+        ]
+        if len(nan_value_keys):
+            raise BadgerEnvVarError(
+                "Failed to connect or get values for the following variables:\n"
+                + f"{nan_value_keys}"
+            )
 
     def get_init_table_header(self):
         table = self.env_box.init_table


### PR DESCRIPTION
Added a function `check_for_nan_vars` which checks for NaN values in var_table. Shows a warning message to notify the user that some variables did not connect or returned invalid values. The function is called after an environment has been selected at the end of `select_env` 

<img width="447" height="169" alt="image" src="https://github.com/user-attachments/assets/c6340d0b-95a9-492c-9aeb-95529ee8608e" />
